### PR TITLE
Fix passing nil value as validation success result

### DIFF
--- a/ballerina/tests/array_constraint_on_record_field_test.bal
+++ b/ballerina/tests/array_constraint_on_record_field_test.bal
@@ -26,6 +26,8 @@ isolated function testNoArrayConstraintsOnRecordField() {
     NoArrayConstraintsOnRecordField|error validation = validate(rec);
     if validation is error {
         test:assertFail("Unexpected error found.");
+    } else {
+        test:assertEquals(validation, rec);
     }
 }
 

--- a/ballerina/tests/array_constraint_on_type_as_record_field_test.bal
+++ b/ballerina/tests/array_constraint_on_type_as_record_field_test.bal
@@ -26,6 +26,8 @@ isolated function testNoArrayConstraintsOnTypeAsRecordField() {
     NoArrayConstraintsOnTypeAsRecordField|error validation = validate(rec);
     if validation is error {
         test:assertFail("Unexpected error found.");
+    } else {
+        test:assertEquals(validation, rec);
     }
 }
 

--- a/ballerina/tests/array_constraint_on_type_test.bal
+++ b/ballerina/tests/array_constraint_on_type_test.bal
@@ -24,6 +24,8 @@ isolated function testNoArrayConstraintsOnType() {
     NoArrayConstraintsOnType|error validation = validate(typ);
     if validation is error {
         test:assertFail("Unexpected error found.");
+    } else {
+        test:assertEquals(validation, typ);
     }
 }
 

--- a/ballerina/tests/float_constraint_on_record_field_test.bal
+++ b/ballerina/tests/float_constraint_on_record_field_test.bal
@@ -26,6 +26,8 @@ isolated function testNoFloatConstraintsOnRecordField() {
     NoFloatConstraintsOnRecordField|error validation = validate(rec);
     if validation is error {
         test:assertFail("Unexpected error found.");
+    } else {
+        test:assertEquals(validation, rec);
     }
 }
 

--- a/ballerina/tests/float_constraint_on_type_as_record_field_test.bal
+++ b/ballerina/tests/float_constraint_on_type_as_record_field_test.bal
@@ -26,6 +26,8 @@ isolated function testNoFloatConstraintsOnTypeAsRecordField() {
     NoFloatConstraintsOnTypeAsRecordField|error validation = validate(rec);
     if validation is error {
         test:assertFail("Unexpected error found.");
+    } else {
+        test:assertEquals(validation, rec);
     }
 }
 

--- a/ballerina/tests/float_constraint_on_type_test.bal
+++ b/ballerina/tests/float_constraint_on_type_test.bal
@@ -142,6 +142,8 @@ isolated function testFloatConstraintMaxValueExclusiveOnTypeSuccess() {
     FloatConstraintMaxValueExclusiveOnType|error validation = validate(typ);
     if validation is error {
         test:assertFail("Unexpected error found.");
+    } else {
+        test:assertEquals(validation, typ);
     }
 }
 

--- a/ballerina/tests/int_constraint_on_record_field_test.bal
+++ b/ballerina/tests/int_constraint_on_record_field_test.bal
@@ -26,6 +26,8 @@ isolated function testNoIntConstraintsOnRecordField() {
     NoIntConstraintsOnRecordField|error validation = validate(rec);
     if validation is error {
         test:assertFail("Unexpected error found.");
+    } else {
+        test:assertEquals(validation, rec);
     }
 }
 

--- a/ballerina/tests/int_constraint_on_type_as_record_field_test.bal
+++ b/ballerina/tests/int_constraint_on_type_as_record_field_test.bal
@@ -26,6 +26,8 @@ isolated function testNoIntConstraintsOnTypeAsRecordField() {
     NoIntConstraintsOnTypeAsRecordField|error validation = validate(rec);
     if validation is error {
         test:assertFail("Unexpected error found.");
+    } else {
+        test:assertEquals(validation, rec);
     }
 }
 

--- a/ballerina/tests/int_constraint_on_type_test.bal
+++ b/ballerina/tests/int_constraint_on_type_test.bal
@@ -24,6 +24,8 @@ isolated function testNoIntConstraintsOnType() {
     NoIntConstraintsOnType|error validation = validate(typ);
     if validation is error {
         test:assertFail("Unexpected error found.");
+    } else {
+        test:assertEquals(validation, typ);
     }
 }
 

--- a/ballerina/tests/number_constraint_on_record_field_test.bal
+++ b/ballerina/tests/number_constraint_on_record_field_test.bal
@@ -26,6 +26,8 @@ isolated function testNoNumberConstraintsOnRecordField() {
     NoNumberConstraintsOnRecordField|error validation = validate(rec);
     if validation is error {
         test:assertFail("Unexpected error found.");
+    } else {
+        test:assertEquals(validation, rec);
     }
 }
 

--- a/ballerina/tests/number_constraint_on_type_as_record_field_test.bal
+++ b/ballerina/tests/number_constraint_on_type_as_record_field_test.bal
@@ -26,6 +26,8 @@ isolated function testNoNumberConstraintsOnTypeAsRecordField() {
     NoNumberConstraintsOnTypeAsRecordField|error validation = validate(rec);
     if validation is error {
         test:assertFail("Unexpected error found.");
+    } else {
+        test:assertEquals(validation, rec);
     }
 }
 

--- a/ballerina/tests/number_constraint_on_type_test.bal
+++ b/ballerina/tests/number_constraint_on_type_test.bal
@@ -24,6 +24,8 @@ isolated function testNoNumberConstraintsOnType() {
     NoNumberConstraintsOnType|error validation = validate(typ);
     if validation is error {
         test:assertFail("Unexpected error found.");
+    } else {
+        test:assertEquals(validation, typ);
     }
 }
 

--- a/ballerina/tests/string_constraint_on_record_field_test.bal
+++ b/ballerina/tests/string_constraint_on_record_field_test.bal
@@ -26,6 +26,8 @@ isolated function testNoStringConstraintsOnRecordField() {
     NoStringConstraintsOnRecordField|error validation = validate(rec);
     if validation is error {
         test:assertFail("Unexpected error found.");
+    } else {
+        test:assertEquals(validation, rec);
     }
 }
 

--- a/ballerina/tests/string_constraint_on_type_as_record_field_test.bal
+++ b/ballerina/tests/string_constraint_on_type_as_record_field_test.bal
@@ -26,6 +26,8 @@ isolated function testNoStringConstraintsOnTypeAsRecordField() {
     NoStringConstraintsOnTypeAsRecordField|error validation = validate(rec);
     if validation is error {
         test:assertFail("Unexpected error found.");
+    } else {
+        test:assertEquals(validation, rec);
     }
 }
 

--- a/ballerina/tests/string_constraint_on_type_test.bal
+++ b/ballerina/tests/string_constraint_on_type_test.bal
@@ -24,6 +24,8 @@ isolated function testNoStringConstraintsOnType() {
     NoStringConstraintsOnType|error validation = validate(typ);
     if validation is error {
         test:assertFail("Unexpected error found.");
+    } else {
+        test:assertEquals(validation, typ);
     }
 }
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,3 +2,11 @@
 This file contains all the notable changes done to the Ballerina Constraint package through the releases.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- [Implement Ballerina Constraint Package - Phase 1](https://github.com/ballerina-platform/ballerina-standard-library/issues/2861)
+
+### Fixed
+- [Passing the typedesc as a param to the constraint() method returns () in success case ](https://github.com/ballerina-platform/ballerina-standard-library/issues/3107)

--- a/native/src/main/java/io/ballerina/stdlib/constraint/Constraints.java
+++ b/native/src/main/java/io/ballerina/stdlib/constraint/Constraints.java
@@ -45,7 +45,7 @@ public class Constraints {
             if (!failedConstraints.isEmpty()) {
                 return ErrorUtils.buildValidationError(failedConstraints);
             }
-            return null;
+            return value;
         } catch (RuntimeException e) {
             return ErrorUtils.buildUnexpectedError();
         }


### PR DESCRIPTION
## Purpose
This PR fix the bug of `()` value as the validation success results instead of the actual value.

Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/3107

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [ ] ~Updated the spec~
