### PR TITLE
Improve constraint error message as JsonPath expression

### DIFF
--- a/ballerina/tests/advanced_constraint_test.bal
+++ b/ballerina/tests/advanced_constraint_test.bal
@@ -44,7 +44,7 @@ isolated function testMultipleConstraintFailure1() {
     Person rec = {name: "John", age: 18};
     Person|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$.name=>minLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.name:minLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -55,7 +55,7 @@ isolated function testMultipleConstraintFailure2() {
     Person rec = {name: "John Steve", age: 18};
     Person|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$.name=>maxLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.name:maxLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -66,7 +66,7 @@ isolated function testMultipleConstraintFailure3() {
     Person rec = {name: "Steve", age: 16};
     Person|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$.age=>minValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.age:minValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -77,7 +77,7 @@ isolated function testMultipleConstraintFailure4() {
     Person rec = {name: "John", age: 16};
     Person|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$.age=>minValue','$.name=>minLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.age:minValue','$.name:minLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -119,7 +119,7 @@ isolated function testMultipleConstraintOnSingleFieldFailure1() {
     Student rec = {name: "Steve", age: 16};
     Student|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$.age=>minValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.age:minValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -130,7 +130,7 @@ isolated function testMultipleConstraintOnSingleFieldFailure2() {
     Student rec = {name: "Steve", age: 55};
     Student|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$.age=>maxValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.age:maxValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -178,7 +178,7 @@ isolated function testNestedRecordFailure1() {
     Foo foo = {value: "Bob", bar: {value: "Steve", baz: [{value: 50}, {value: 75}]}};
     Foo|error validation = validate(foo);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$.value=>length' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value:length' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -189,7 +189,7 @@ isolated function testNestedRecordFailure2() {
     Foo foo = {value: "Alice", bar: {value: "Bob", baz: [{value: 50}, {value: 75}]}};
     Foo|error validation = validate(foo);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$.bar.value=>minLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.bar.value:minLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -200,7 +200,7 @@ isolated function testNestedRecordFailure3() {
     Foo foo = {value: "Alice", bar: {value: "Steve", baz: [{value: 50}]}};
     Foo|error validation = validate(foo);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$.bar.baz=>minLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.bar.baz:minLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -211,7 +211,7 @@ isolated function testNestedRecordFailure4() {
     Foo foo = {value: "Alice", bar: {value: "Steve", baz: [{value: 50}, {value: 125}]}};
     Foo|error validation = validate(foo);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$.bar.baz[1].value=>maxValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.bar.baz[1].value:maxValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -222,7 +222,7 @@ isolated function testNestedRecordFailure5() {
     Foo foo = {value: "Eve", bar: {value: "Bob", baz: [{value: 125}]}};
     Foo|error validation = validate(foo);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$.bar.baz=>minLength','$.bar.baz[0].value=>maxValue','$.bar.value=>minLength','$.value=>length' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.bar.baz:minLength','$.bar.baz[0].value:maxValue','$.bar.value=>minLength','$.value=>length' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }

--- a/ballerina/tests/advanced_constraint_test.bal
+++ b/ballerina/tests/advanced_constraint_test.bal
@@ -44,7 +44,7 @@ isolated function testMultipleConstraintFailure1() {
     Person rec = {name: "John", age: 18};
     Person|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.name=>minLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -55,7 +55,7 @@ isolated function testMultipleConstraintFailure2() {
     Person rec = {name: "John Steve", age: 18};
     Person|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.name=>maxLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -66,7 +66,7 @@ isolated function testMultipleConstraintFailure3() {
     Person rec = {name: "Steve", age: 16};
     Person|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.age=>minValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -77,7 +77,7 @@ isolated function testMultipleConstraintFailure4() {
     Person rec = {name: "John", age: 16};
     Person|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValue','minLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.age=>minValue','$.name=>minLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -119,7 +119,7 @@ isolated function testMultipleConstraintOnSingleFieldFailure1() {
     Student rec = {name: "Steve", age: 16};
     Student|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.age=>minValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -130,7 +130,7 @@ isolated function testMultipleConstraintOnSingleFieldFailure2() {
     Student rec = {name: "Steve", age: 55};
     Student|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.age=>maxValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -178,7 +178,7 @@ isolated function testNestedRecordFailure1() {
     Foo foo = {value: "Bob", bar: {value: "Steve", baz: [{value: 50}, {value: 75}]}};
     Foo|error validation = validate(foo);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'length' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>length' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -189,7 +189,7 @@ isolated function testNestedRecordFailure2() {
     Foo foo = {value: "Alice", bar: {value: "Bob", baz: [{value: 50}, {value: 75}]}};
     Foo|error validation = validate(foo);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.bar.value=>minLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -200,7 +200,7 @@ isolated function testNestedRecordFailure3() {
     Foo foo = {value: "Alice", bar: {value: "Steve", baz: [{value: 50}]}};
     Foo|error validation = validate(foo);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.bar.baz=>minLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -211,7 +211,7 @@ isolated function testNestedRecordFailure4() {
     Foo foo = {value: "Alice", bar: {value: "Steve", baz: [{value: 50}, {value: 125}]}};
     Foo|error validation = validate(foo);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.bar.baz[1].value=>maxValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -222,7 +222,7 @@ isolated function testNestedRecordFailure5() {
     Foo foo = {value: "Eve", bar: {value: "Bob", baz: [{value: 125}]}};
     Foo|error validation = validate(foo);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxValue','minLength','length' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.bar.baz=>minLength','$.bar.baz[0].value=>maxValue','$.bar.value=>minLength','$.value=>length' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -254,7 +254,7 @@ isolated function testNestedTypeFailure1() {
     PositiveIntArray arr = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
     PositiveIntArray|error validation = validate(arr);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$=>maxLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -265,7 +265,7 @@ isolated function testNestedTypeFailure2() {
     PositiveIntArray arr = [1, 2, 3, 4, -5, 6, 7, 8, 9, -10];
     PositiveIntArray|error validation = validate(arr);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$[4]=>minValue','$[9]=>minValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -276,7 +276,7 @@ isolated function testNestedTypeFailure3() {
     PositiveIntArray arr = [1, 2, 3, 4, -5, 6, 7, 8, 9, -10, 11];
     PositiveIntArray|error validation = validate(arr);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValue','maxLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$=>maxLength','$[4]=>minValue','$[9]=>minValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -325,7 +325,7 @@ isolated function testRecursiveAnnotationsOnRecordAndTypeFailure1() {
     TeacherArray arr = [{name: "Alice", age: 20, qualifications: ["BSC"]}];
     TeacherArray|error validation = validate(arr);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$=>minLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -336,7 +336,7 @@ isolated function testRecursiveAnnotationsOnRecordAndTypeFailure2() {
     TeacherArray arr = [{name: "Alice", age: 20, qualifications: ["BSc"]}, {name: "Bob", age: 30, qualifications: ["BSc", "MSc"]}];
     TeacherArray|error validation = validate(arr);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'length' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$[1].name=>length' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -347,7 +347,7 @@ isolated function testRecursiveAnnotationsOnRecordAndTypeFailure3() {
     TeacherArray arr = [{name: "Alice", age: 15, qualifications: ["BSc"]}, {name: "Peter", age: 30, qualifications: ["BSc", "MSc"]}];
     TeacherArray|error validation = validate(arr);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$[0].age=>minValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -358,7 +358,7 @@ isolated function testRecursiveAnnotationsOnRecordAndTypeFailure4() {
     TeacherArray arr = [{name: "Alice", age: 20, qualifications: ["BSc"]}, {name: "Peter", age: 30, qualifications: []}];
     TeacherArray|error validation = validate(arr);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$[1].qualifications=>minLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -369,7 +369,7 @@ isolated function testRecursiveAnnotationsOnRecordAndTypeFailure5() {
     TeacherArray arr = [{name: "Alice", age: 20, qualifications: ["BSc"]}, {name: "Peter", age: 30, qualifications: ["Bachelors", "MSc"]}];
     TeacherArray|error validation = validate(arr);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'length' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$[1].qualifications[0]=>length' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -380,7 +380,7 @@ isolated function testRecursiveAnnotationsOnRecordAndTypeFailure6() {
     TeacherArray arr = [{name: "Alice", age: 15, qualifications: ["Bachelors"]}, {name: "Bob", age: 16, qualifications: []}];
     TeacherArray|error validation = validate(arr);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValue','minLength','length' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$[0].age=>minValue','$[0].qualifications[0]=>length','$[1].age=>minValue','$[1].name=>length','$[1].qualifications=>minLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -420,7 +420,7 @@ isolated function testRecursiveAnnotationsOnTypeAndRecordFailure1() {
     Employee rec = {username: "Alice", qualifications: [{name: "BSc"}, {name: "MSc"}]};
     Employee|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.username=>maxLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -431,7 +431,7 @@ isolated function testRecursiveAnnotationsOnTypeAndRecordFailure2() {
     Employee rec = {username: "Bob", qualifications: [{name: "BSc"}]};
     Employee|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.qualifications=>minLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -442,7 +442,7 @@ isolated function testRecursiveAnnotationsOnTypeAndRecordFailure3() {
     Employee rec = {username: "Bob", qualifications: [{name: "Bachelors"}, {name: "Masters"}]};
     Employee|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'length' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.qualifications[0].name=>length','$.qualifications[1].name=>length' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -453,7 +453,7 @@ isolated function testRecursiveAnnotationsOnTypeAndRecordFailure4() {
     Employee rec = {username: "Alice", qualifications: [{name: "Bachelors"}]};
     Employee|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minLength','length','maxLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.qualifications=>minLength','$.qualifications[0].name=>length','$.username=>maxLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }

--- a/ballerina/tests/array_constraint_on_record_field_test.bal
+++ b/ballerina/tests/array_constraint_on_record_field_test.bal
@@ -52,7 +52,7 @@ isolated function testArrayConstraintLengthOnRecordFieldFailure1() {
     ArrayConstraintLengthOnRecordField rec = {value: [(), true, 123]};
     ArrayConstraintLengthOnRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'length' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>length' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -63,7 +63,7 @@ isolated function testArrayConstraintLengthOnRecordFieldFailure2() {
     ArrayConstraintLengthOnRecordField rec = {value: [(), true, 123, 123.45, 123.45d, "s3cr3t", xml `<book>The Lost World</book>`, {foo: "bar"}, table key('key) [{'key: 1, value: "foo"}]]};
     ArrayConstraintLengthOnRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'length' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>length' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -99,7 +99,7 @@ isolated function testArrayConstraintMinLengthOnRecordFieldFailure() {
     ArrayConstraintMinLengthOnRecordField rec = {value: [(), true, 123]};
     ArrayConstraintMinLengthOnRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>minLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -135,7 +135,7 @@ isolated function testArrayConstraintMaxLengthOnRecordFieldFailure() {
     ArrayConstraintMaxLengthOnRecordField rec = {value: [(), true, 123, 123.45, 123.45d, "s3cr3t", xml `<book>The Lost World</book>`, {foo: "bar"}, table key('key) [{'key: 1, value: "foo"}]]};
     ArrayConstraintMaxLengthOnRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>maxLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -181,7 +181,7 @@ isolated function testArrayConstraintOnRecordFieldFailure1() {
     ArrayConstraintOnRecordField rec = {value: [(), true, 123]};
     ArrayConstraintOnRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>minLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -192,7 +192,7 @@ isolated function testArrayConstraintOnRecordFieldFailure2() {
     ArrayConstraintOnRecordField rec = {value: [(), true, 123, 123.45, 123.45d, "s3cr3t", (), true, 123, 123.45, 123.45d, "s3cr3t", (), true, 123, 123.45, 123.45d, "s3cr3t"]};
     ArrayConstraintOnRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>maxLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -229,7 +229,7 @@ isolated function testArrayConstraintOnUnionRecordFieldFailure1() {
     ArrayConstraintOnUnionRecordField rec = {value: [1, 2, 3]};
     ArrayConstraintOnUnionRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>minLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -240,7 +240,7 @@ isolated function testArrayConstraintOnUnionRecordFieldFailure2() {
     ArrayConstraintOnUnionRecordField rec = {value: ["a", "b", "c"]};
     ArrayConstraintOnUnionRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>minLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -251,7 +251,7 @@ isolated function testArrayConstraintOnRecordFieldFailure3() {
     ArrayConstraintOnUnionRecordField rec = {value: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]};
     ArrayConstraintOnUnionRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>maxLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -262,7 +262,7 @@ isolated function testArrayConstraintOnRecordFieldFailure4() {
     ArrayConstraintOnUnionRecordField rec = {value: ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o"]};
     ArrayConstraintOnUnionRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>maxLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }

--- a/ballerina/tests/array_constraint_on_record_field_test.bal
+++ b/ballerina/tests/array_constraint_on_record_field_test.bal
@@ -52,7 +52,7 @@ isolated function testArrayConstraintLengthOnRecordFieldFailure1() {
     ArrayConstraintLengthOnRecordField rec = {value: [(), true, 123]};
     ArrayConstraintLengthOnRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$.value=>length' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value:length' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -63,7 +63,7 @@ isolated function testArrayConstraintLengthOnRecordFieldFailure2() {
     ArrayConstraintLengthOnRecordField rec = {value: [(), true, 123, 123.45, 123.45d, "s3cr3t", xml `<book>The Lost World</book>`, {foo: "bar"}, table key('key) [{'key: 1, value: "foo"}]]};
     ArrayConstraintLengthOnRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$.value=>length' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value:length' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -99,7 +99,7 @@ isolated function testArrayConstraintMinLengthOnRecordFieldFailure() {
     ArrayConstraintMinLengthOnRecordField rec = {value: [(), true, 123]};
     ArrayConstraintMinLengthOnRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$.value=>minLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value:minLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -135,7 +135,7 @@ isolated function testArrayConstraintMaxLengthOnRecordFieldFailure() {
     ArrayConstraintMaxLengthOnRecordField rec = {value: [(), true, 123, 123.45, 123.45d, "s3cr3t", xml `<book>The Lost World</book>`, {foo: "bar"}, table key('key) [{'key: 1, value: "foo"}]]};
     ArrayConstraintMaxLengthOnRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$.value=>maxLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value:maxLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -181,7 +181,7 @@ isolated function testArrayConstraintOnRecordFieldFailure1() {
     ArrayConstraintOnRecordField rec = {value: [(), true, 123]};
     ArrayConstraintOnRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$.value=>minLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value:minLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -192,7 +192,7 @@ isolated function testArrayConstraintOnRecordFieldFailure2() {
     ArrayConstraintOnRecordField rec = {value: [(), true, 123, 123.45, 123.45d, "s3cr3t", (), true, 123, 123.45, 123.45d, "s3cr3t", (), true, 123, 123.45, 123.45d, "s3cr3t"]};
     ArrayConstraintOnRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$.value=>maxLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value:maxLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -229,7 +229,7 @@ isolated function testArrayConstraintOnUnionRecordFieldFailure1() {
     ArrayConstraintOnUnionRecordField rec = {value: [1, 2, 3]};
     ArrayConstraintOnUnionRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$.value=>minLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value:minLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -240,7 +240,7 @@ isolated function testArrayConstraintOnUnionRecordFieldFailure2() {
     ArrayConstraintOnUnionRecordField rec = {value: ["a", "b", "c"]};
     ArrayConstraintOnUnionRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$.value=>minLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value:minLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -251,7 +251,7 @@ isolated function testArrayConstraintOnRecordFieldFailure3() {
     ArrayConstraintOnUnionRecordField rec = {value: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]};
     ArrayConstraintOnUnionRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$.value=>maxLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value:maxLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }

--- a/ballerina/tests/array_constraint_on_type_as_record_field_test.bal
+++ b/ballerina/tests/array_constraint_on_type_as_record_field_test.bal
@@ -49,7 +49,7 @@ isolated function testArrayConstraintLengthOnTypeAsRecordFieldFailure1() {
     ArrayConstraintLengthOnTypeAsRecordField rec = {value: [(), true, 123]};
     ArrayConstraintLengthOnTypeAsRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'length' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>length' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -60,7 +60,7 @@ isolated function testArrayConstraintLengthOnTypeAsRecordFieldFailure2() {
     ArrayConstraintLengthOnTypeAsRecordField rec = {value: [(), true, 123, 123.45, 123.45d, "s3cr3t", xml `<book>The Lost World</book>`, {foo: "bar"}, table key('key) [{'key: 1, value: "foo"}]]};
     ArrayConstraintLengthOnTypeAsRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'length' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>length' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -93,7 +93,7 @@ isolated function testArrayConstraintMinLengthOnTypeAsRecordFieldFailure() {
     ArrayConstraintMinLengthOnTypeAsRecordField rec = {value: [(), true, 123]};
     ArrayConstraintMinLengthOnTypeAsRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>minLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -126,7 +126,7 @@ isolated function testArrayConstraintMaxLengthOnTypeAsRecordFieldFailure() {
     ArrayConstraintMaxLengthOnTypeAsRecordField rec = {value: [(), true, 123, 123.45, 123.45d, "s3cr3t", xml `<book>The Lost World</book>`, {foo: "bar"}, table key('key) [{'key: 1, value: "foo"}]]};
     ArrayConstraintMaxLengthOnTypeAsRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>maxLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -168,7 +168,7 @@ isolated function testArrayConstraintOnTypeAsRecordFieldFailure1() {
     ArrayConstraintOnTypeAsRecordField rec = {value: [(), true, 123]};
     ArrayConstraintOnTypeAsRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>minLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -179,7 +179,7 @@ isolated function testArrayConstraintOnTypeAsRecordFieldFailure2() {
     ArrayConstraintOnTypeAsRecordField rec = {value: [(), true, 123, 123.45, 123.45d, "s3cr3t", (), true, 123, 123.45, 123.45d, "s3cr3t", (), true, 123, 123.45, 123.45d, "s3cr3t"]};
     ArrayConstraintOnTypeAsRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>maxLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -214,7 +214,7 @@ isolated function testArrayConstraintOnUnionTypeAsRecordFieldFailure1() {
     ArrayConstraintOnUnionTypeAsRecordField rec = {value: [1, 2, 3]};
     ArrayConstraintOnUnionTypeAsRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>minLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -225,7 +225,7 @@ isolated function testArrayConstraintOnUnionTypeAsRecordFieldFailure2() {
     ArrayConstraintOnUnionTypeAsRecordField rec = {value: ["a", "b", "c"]};
     ArrayConstraintOnUnionTypeAsRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>minLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -236,7 +236,7 @@ isolated function testArrayConstraintOnUnionTypeAsRecordFieldFailure3() {
     ArrayConstraintOnUnionTypeAsRecordField rec = {value: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]};
     ArrayConstraintOnUnionTypeAsRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>maxLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -247,7 +247,7 @@ isolated function testArrayConstraintOnUnionTypeAsRecordFieldFailure4() {
     ArrayConstraintOnUnionTypeAsRecordField rec = {value: ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o"]};
     ArrayConstraintOnUnionTypeAsRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>maxLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }

--- a/ballerina/tests/array_constraint_on_type_test.bal
+++ b/ballerina/tests/array_constraint_on_type_test.bal
@@ -48,7 +48,7 @@ isolated function testArrayConstraintLengthOnTypeFailure1() {
     ArrayConstraintLengthOnType typ = [(), true, 123];
     ArrayConstraintLengthOnType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'length' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$=>length' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -59,7 +59,7 @@ isolated function testArrayConstraintLengthOnTypeFailure2() {
     ArrayConstraintLengthOnType typ = [(), true, 123, 123.45, 123.45d, "s3cr3t", xml `<book>The Lost World</book>`, {foo: "bar"}, table key('key) [{'key: 1, value: "foo"}]];
     ArrayConstraintLengthOnType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'length' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$=>length' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -93,7 +93,7 @@ isolated function testArrayConstraintMinLengthOnTypeFailure() {
     ArrayConstraintMinLengthOnType typ = [(), true, 123];
     ArrayConstraintMinLengthOnType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$=>minLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -127,7 +127,7 @@ isolated function testArrayConstraintMaxLengthOnTypeFailure() {
     ArrayConstraintMaxLengthOnType typ = [(), true, 123, 123.45, 123.45d, "s3cr3t", xml `<book>The Lost World</book>`, {foo: "bar"}, table key('key) [{'key: 1, value: "foo"}]];
     ArrayConstraintMaxLengthOnType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$=>maxLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -171,7 +171,7 @@ isolated function testArrayConstraintOnTypeFailure1() {
     ArrayConstraintOnType typ = [(), true, 123];
     ArrayConstraintOnType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$=>minLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -182,7 +182,7 @@ isolated function testArrayConstraintOnTypeFailure2() {
     ArrayConstraintOnType typ = [(), true, 123, 123.45, 123.45d, "s3cr3t", (), true, 123, 123.45, 123.45d, "s3cr3t", (), true, 123, 123.45, 123.45d, "s3cr3t"];
     ArrayConstraintOnType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$=>maxLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -219,7 +219,7 @@ isolated function testArrayConstraintOnUnionTypeFailure1() {
     ArrayConstraintOnUnionType typ = [1, 2, 3];
     ArrayConstraintOnUnionType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$=>minLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -230,7 +230,7 @@ isolated function testArrayConstraintOnUnionTypeFailure2() {
     ArrayConstraintOnUnionType typ = ["a", "b", "c"];
     ArrayConstraintOnUnionType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$=>minLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -241,7 +241,7 @@ isolated function testArrayConstraintOnUnionTypeFailure3() {
     ArrayConstraintOnUnionType typ = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
     ArrayConstraintOnUnionType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$=>maxLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -252,7 +252,7 @@ isolated function testArrayConstraintOnUnionTypeFailure4() {
     ArrayConstraintOnUnionType typ = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o"];
     ArrayConstraintOnUnionType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$=>maxLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }

--- a/ballerina/tests/array_constraint_on_type_test.bal
+++ b/ballerina/tests/array_constraint_on_type_test.bal
@@ -48,7 +48,7 @@ isolated function testArrayConstraintLengthOnTypeFailure1() {
     ArrayConstraintLengthOnType typ = [(), true, 123];
     ArrayConstraintLengthOnType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$=>length' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$:length' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -59,7 +59,7 @@ isolated function testArrayConstraintLengthOnTypeFailure2() {
     ArrayConstraintLengthOnType typ = [(), true, 123, 123.45, 123.45d, "s3cr3t", xml `<book>The Lost World</book>`, {foo: "bar"}, table key('key) [{'key: 1, value: "foo"}]];
     ArrayConstraintLengthOnType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$=>length' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$:length' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -93,7 +93,7 @@ isolated function testArrayConstraintMinLengthOnTypeFailure() {
     ArrayConstraintMinLengthOnType typ = [(), true, 123];
     ArrayConstraintMinLengthOnType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$=>minLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$:minLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -127,7 +127,7 @@ isolated function testArrayConstraintMaxLengthOnTypeFailure() {
     ArrayConstraintMaxLengthOnType typ = [(), true, 123, 123.45, 123.45d, "s3cr3t", xml `<book>The Lost World</book>`, {foo: "bar"}, table key('key) [{'key: 1, value: "foo"}]];
     ArrayConstraintMaxLengthOnType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$=>maxLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$:maxLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -171,7 +171,7 @@ isolated function testArrayConstraintOnTypeFailure1() {
     ArrayConstraintOnType typ = [(), true, 123];
     ArrayConstraintOnType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$=>minLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$:minLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -182,7 +182,7 @@ isolated function testArrayConstraintOnTypeFailure2() {
     ArrayConstraintOnType typ = [(), true, 123, 123.45, 123.45d, "s3cr3t", (), true, 123, 123.45, 123.45d, "s3cr3t", (), true, 123, 123.45, 123.45d, "s3cr3t"];
     ArrayConstraintOnType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$=>maxLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$:maxLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -219,7 +219,7 @@ isolated function testArrayConstraintOnUnionTypeFailure1() {
     ArrayConstraintOnUnionType typ = [1, 2, 3];
     ArrayConstraintOnUnionType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$=>minLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$:minLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -230,7 +230,7 @@ isolated function testArrayConstraintOnUnionTypeFailure2() {
     ArrayConstraintOnUnionType typ = ["a", "b", "c"];
     ArrayConstraintOnUnionType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$=>minLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$:minLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -241,7 +241,7 @@ isolated function testArrayConstraintOnUnionTypeFailure3() {
     ArrayConstraintOnUnionType typ = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
     ArrayConstraintOnUnionType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$=>maxLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$:maxLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -252,7 +252,7 @@ isolated function testArrayConstraintOnUnionTypeFailure4() {
     ArrayConstraintOnUnionType typ = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o"];
     ArrayConstraintOnUnionType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$=>maxLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$:maxLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }

--- a/ballerina/tests/example_constraint_test.bal
+++ b/ballerina/tests/example_constraint_test.bal
@@ -340,7 +340,7 @@ isolated function testSampleFailure1() returns error? {
     rec.customer.currency = "INVALID";
     Order|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$.customer.currency=>length' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.customer.currency:length' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -352,7 +352,7 @@ isolated function testSampleFailure2() returns error? {
     rec.presentment_currency = "INVALID";
     Order|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$.presentment_currency=>length' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.presentment_currency:length' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -364,7 +364,7 @@ isolated function testSampleFailure3() returns error? {
     rec.current_total_discounts_set.shop_money.currency_code = "INVALID";
     Order|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$.current_total_discounts_set.shop_money.currency_code=>length' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.current_total_discounts_set.shop_money.currency_code:length' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -376,7 +376,7 @@ isolated function testSampleFailure4() returns error? {
     rec.fulfillments[0].line_items[0].price_set.shop_money.currency_code = "INVALID";
     Order|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$.fulfillments[0].line_items[0].price_set.shop_money.currency_code=>length' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.fulfillments[0].line_items[0].price_set.shop_money.currency_code:length' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -388,7 +388,7 @@ isolated function testSampleFailure5() returns error? {
     rec.number = -1;
     Order|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$.number=>minValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.number:minValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }

--- a/ballerina/tests/example_constraint_test.bal
+++ b/ballerina/tests/example_constraint_test.bal
@@ -3,328 +3,326 @@ import ballerina/test;
 // Testing multiple types of annotations in a practical sample value
 
 final json & readonly SAMPLE_PAYLOAD = {
-    "order": {
-        "app_id": 488472577,
-        "buyer_accepts_marketing": false,
-        "created_at": "2022-06-28T15:28:38+05:30",
+    "app_id": 488472577,
+    "buyer_accepts_marketing": false,
+    "created_at": "2022-06-28T15:28:38+05:30",
+    "currency": "LKR",
+    "current_total_discounts": "0.00",
+    "current_total_discounts_set": {
+        "shop_money": {
+            "amount": "0.00",
+            "currency_code": "LKR"
+        },
+        "presentment_money": {
+            "amount": "0.00",
+            "currency_code": "LKR"
+        }
+    },
+    "current_total_price": "2500.00",
+    "current_total_price_set": {
+        "shop_money": {
+            "amount": "2500.00",
+            "currency_code": "LKR"
+        },
+        "presentment_money": {
+            "amount": "2500.00",
+            "currency_code": "LKR"
+        }
+    },
+    "current_subtotal_price": "2500.00",
+    "current_subtotal_price_set": {
+        "shop_money": {
+            "amount": "2500.00",
+            "currency_code": "LKR"
+        },
+        "presentment_money": {
+            "amount": "2500.00",
+            "currency_code": "LKR"
+        }
+    },
+    "current_total_tax": "0.00",
+    "current_total_tax_set": {
+        "shop_money": {
+            "amount": "0.00",
+            "currency_code": "LKR"
+        },
+        "presentment_money": {
+            "amount": "0.00",
+            "currency_code": "LKR"
+        }
+    },
+    "customer": {
+        "accepts_marketing": false,
+        "accepts_marketing_updated_at": "2022-06-02T14:33:08+05:30",
         "currency": "LKR",
-        "current_total_discounts": "0.00",
-        "current_total_discounts_set": {
-            "shop_money": {
-                "amount": "0.00",
-                "currency_code": "LKR"
+        "created_at": "2022-06-02T13:50:48+05:30",
+        "email": "roland.hewage@gmail.com",
+        "id": 6239032443131,
+        "last_order_id": 4797045473531,
+        "last_order_name": "#1101",
+        "orders_count": 90,
+        "state": "disabled",
+        "tags": "",
+        "tax_exempt": false,
+        "tax_exemptions": [
+
+        ],
+        "total_spent": "218215.41",
+        "updated_at": "2022-06-28T15:28:39+05:30",
+        "verified_email": true,
+        "admin_graphql_api_id": "gid://shopify/Customer/6239032443131"
+    },
+    "discount_applications": [
+
+    ],
+    "discount_codes": [
+
+    ],
+    "email": "roland.hewage@gmail.com",
+    "estimated_taxes": false,
+    "financial_status": "paid",
+    "fulfillments": [
+        {
+            "created_at": "2022-06-28T15:28:39+05:30",
+            "id": 4290265317627,
+            "line_items": [
+                {
+                    "id": 12244791755003,
+                    "variant_id": 43095501734139,
+                    "title": "Long sleeve t-shirt",
+                    "quantity": 1,
+                    "price": "2500.00",
+                    "price_set": {
+                        "shop_money": {
+                            "amount": "2500.00",
+                            "currency_code": "LKR"
+                        },
+                        "presentment_money": {
+                            "amount": "2500.00",
+                            "currency_code": "LKR"
+                        }
+                    },
+                    "grams": 180,
+                    "sku": "",
+                    "variant_title": "Medium / Black",
+                    "vendor": "zrhtwochak",
+                    "fulfillment_service": "manual",
+                    "product_id": 7721106571515,
+                    "requires_shipping": true,
+                    "taxable": false,
+                    "gift_card": false,
+                    "name": "Long sleeve t-shirt - Medium / Black",
+                    "variant_inventory_management": "shopify",
+                    "properties": [
+
+                    ],
+                    "product_exists": true,
+                    "fulfillable_quantity": 0,
+                    "total_discount": "0.00",
+                    "fulfillment_status": "fulfilled",
+                    "tax_lines": [
+
+                    ],
+                    "total_discount_set": {
+                        "shop_money": {
+                            "amount": "0.00",
+                            "currency_code": "LKR"
+                        },
+                        "presentment_money": {
+                            "amount": "0.00",
+                            "currency_code": "LKR"
+                        }
+                    },
+                    "discount_allocations": [
+
+                    ],
+                    "admin_graphql_api_id": "gid://shopify/LineItem/12244791755003",
+                    "duties": [
+
+                    ]
+                }
+            ],
+            "location_id": 69263819003,
+            "name": "#1101.1",
+            "order_id": 4797045473531,
+            "origin_address": {
+
             },
-            "presentment_money": {
-                "amount": "0.00",
-                "currency_code": "LKR"
-            }
-        },
-        "current_total_price": "2500.00",
-        "current_total_price_set": {
-            "shop_money": {
-                "amount": "2500.00",
-                "currency_code": "LKR"
+            "receipt": {
+
             },
-            "presentment_money": {
-                "amount": "2500.00",
-                "currency_code": "LKR"
-            }
-        },
-        "current_subtotal_price": "2500.00",
-        "current_subtotal_price_set": {
-            "shop_money": {
-                "amount": "2500.00",
-                "currency_code": "LKR"
-            },
-            "presentment_money": {
-                "amount": "2500.00",
-                "currency_code": "LKR"
-            }
-        },
-        "current_total_tax": "0.00",
-        "current_total_tax_set": {
-            "shop_money": {
-                "amount": "0.00",
-                "currency_code": "LKR"
-            },
-            "presentment_money": {
-                "amount": "0.00",
-                "currency_code": "LKR"
-            }
-        },
-        "customer": {
-            "accepts_marketing": false,
-            "accepts_marketing_updated_at": "2022-06-02T14:33:08+05:30",
-            "currency": "LKR",
-            "created_at": "2022-06-02T13:50:48+05:30",
-            "email": "roland.hewage@gmail.com",
-            "id": 6239032443131,
-            "last_order_id": 4797045473531,
-            "last_order_name": "#1101",
-            "orders_count": 90,
-            "state": "disabled",
-            "tags": "",
-            "tax_exempt": false,
-            "tax_exemptions": [
+            "service": "manual",
+            "status": "success",
+            "tracking_numbers": [
 
             ],
-            "total_spent": "218215.41",
+            "tracking_urls": [
+
+            ],
             "updated_at": "2022-06-28T15:28:39+05:30",
-            "verified_email": true,
-            "admin_graphql_api_id": "gid://shopify/Customer/6239032443131"
-        },
-        "discount_applications": [
-
-        ],
-        "discount_codes": [
-
-        ],
-        "email": "roland.hewage@gmail.com",
-        "estimated_taxes": false,
-        "financial_status": "paid",
-        "fulfillments": [
-            {
-                "created_at": "2022-06-28T15:28:39+05:30",
-                "id": 4290265317627,
-                "line_items": [
-                    {
-                        "id": 12244791755003,
-                        "variant_id": 43095501734139,
-                        "title": "Long sleeve t-shirt",
-                        "quantity": 1,
-                        "price": "2500.00",
-                        "price_set": {
-                            "shop_money": {
-                                "amount": "2500.00",
-                                "currency_code": "LKR"
-                            },
-                            "presentment_money": {
-                                "amount": "2500.00",
-                                "currency_code": "LKR"
-                            }
-                        },
-                        "grams": 180,
-                        "sku": "",
-                        "variant_title": "Medium / Black",
-                        "vendor": "zrhtwochak",
-                        "fulfillment_service": "manual",
-                        "product_id": 7721106571515,
-                        "requires_shipping": true,
-                        "taxable": false,
-                        "gift_card": false,
-                        "name": "Long sleeve t-shirt - Medium / Black",
-                        "variant_inventory_management": "shopify",
-                        "properties": [
-
-                        ],
-                        "product_exists": true,
-                        "fulfillable_quantity": 0,
-                        "total_discount": "0.00",
-                        "fulfillment_status": "fulfilled",
-                        "tax_lines": [
-
-                        ],
-                        "total_discount_set": {
-                            "shop_money": {
-                                "amount": "0.00",
-                                "currency_code": "LKR"
-                            },
-                            "presentment_money": {
-                                "amount": "0.00",
-                                "currency_code": "LKR"
-                            }
-                        },
-                        "discount_allocations": [
-
-                        ],
-                        "admin_graphql_api_id": "gid://shopify/LineItem/12244791755003",
-                        "duties": [
-
-                        ]
-                    }
-                ],
-                "location_id": 69263819003,
-                "name": "#1101.1",
-                "order_id": 4797045473531,
-                "origin_address": {
-
+            "admin_graphql_api_id": "gid://shopify/Fulfillment/4290265317627"
+        }
+    ],
+    "fulfillment_status": "fulfilled",
+    "gateway": "",
+    "id": 4797045473531,
+    "line_items": [
+        {
+            "id": 12244791755003,
+            "variant_id": 43095501734139,
+            "title": "Long sleeve t-shirt",
+            "quantity": 1,
+            "price": "2500.00",
+            "price_set": {
+                "shop_money": {
+                    "amount": "2500.00",
+                    "currency_code": "LKR"
                 },
-                "receipt": {
+                "presentment_money": {
+                    "amount": "2500.00",
+                    "currency_code": "LKR"
+                }
+            },
+            "grams": 180,
+            "sku": "",
+            "variant_title": "Medium / Black",
+            "vendor": "zrhtwochak",
+            "fulfillment_service": "manual",
+            "product_id": 7721106571515,
+            "requires_shipping": true,
+            "taxable": false,
+            "gift_card": false,
+            "name": "Long sleeve t-shirt - Medium / Black",
+            "variant_inventory_management": "shopify",
+            "properties": [
 
+            ],
+            "product_exists": true,
+            "fulfillable_quantity": 0,
+            "total_discount": "0.00",
+            "fulfillment_status": "fulfilled",
+            "tax_lines": [
+
+            ],
+            "total_discount_set": {
+                "shop_money": {
+                    "amount": "0.00",
+                    "currency_code": "LKR"
                 },
-                "service": "manual",
-                "status": "success",
-                "tracking_numbers": [
-
-                ],
-                "tracking_urls": [
-
-                ],
-                "updated_at": "2022-06-28T15:28:39+05:30",
-                "admin_graphql_api_id": "gid://shopify/Fulfillment/4290265317627"
-            }
-        ],
-        "fulfillment_status": "fulfilled",
-        "gateway": "",
-        "id": 4797045473531,
-        "line_items": [
-            {
-                "id": 12244791755003,
-                "variant_id": 43095501734139,
-                "title": "Long sleeve t-shirt",
-                "quantity": 1,
-                "price": "2500.00",
-                "price_set": {
-                    "shop_money": {
-                        "amount": "2500.00",
-                        "currency_code": "LKR"
-                    },
-                    "presentment_money": {
-                        "amount": "2500.00",
-                        "currency_code": "LKR"
-                    }
-                },
-                "grams": 180,
-                "sku": "",
-                "variant_title": "Medium / Black",
-                "vendor": "zrhtwochak",
-                "fulfillment_service": "manual",
-                "product_id": 7721106571515,
-                "requires_shipping": true,
-                "taxable": false,
-                "gift_card": false,
-                "name": "Long sleeve t-shirt - Medium / Black",
-                "variant_inventory_management": "shopify",
-                "properties": [
-
-                ],
-                "product_exists": true,
-                "fulfillable_quantity": 0,
-                "total_discount": "0.00",
-                "fulfillment_status": "fulfilled",
-                "tax_lines": [
-
-                ],
-                "total_discount_set": {
-                    "shop_money": {
-                        "amount": "0.00",
-                        "currency_code": "LKR"
-                    },
-                    "presentment_money": {
-                        "amount": "0.00",
-                        "currency_code": "LKR"
-                    }
-                },
-                "discount_allocations": [
-
-                ],
-                "admin_graphql_api_id": "gid://shopify/LineItem/12244791755003",
-                "duties": [
-
-                ]
-            }
-        ],
-        "name": "#1101",
-        "note_attributes": [
-
-        ],
-        "number": 101,
-        "order_number": 1101,
-        "payment_gateway_names": [
-
-        ],
-        "presentment_currency": "LKR",
-        "processed_at": "2022-06-28T15:28:38+05:30",
-        "processing_method": "",
-        "refunds": [
-
-        ],
-        "shipping_lines": [
-
-        ],
-        "source_name": "488472577",
-        "subtotal_price": "2500.00",
-        "subtotal_price_set": {
-            "shop_money": {
-                "amount": "2500.00",
-                "currency_code": "LKR"
+                "presentment_money": {
+                    "amount": "0.00",
+                    "currency_code": "LKR"
+                }
             },
-            "presentment_money": {
-                "amount": "2500.00",
-                "currency_code": "LKR"
-            }
-        },
-        "tags": "",
-        "tax_lines": [
+            "discount_allocations": [
 
-        ],
-        "taxes_included": false,
-        "test": false,
-        "token": "03dd268fd532d709a2ae7285fee54e85",
-        "total_discounts": "0.00",
-        "total_discounts_set": {
-            "shop_money": {
-                "amount": "0.00",
-                "currency_code": "LKR"
-            },
-            "presentment_money": {
-                "amount": "0.00",
-                "currency_code": "LKR"
-            }
+            ],
+            "admin_graphql_api_id": "gid://shopify/LineItem/12244791755003",
+            "duties": [
+
+            ]
+        }
+    ],
+    "name": "#1101",
+    "note_attributes": [
+
+    ],
+    "number": 101,
+    "order_number": 1101,
+    "payment_gateway_names": [
+
+    ],
+    "presentment_currency": "LKR",
+    "processed_at": "2022-06-28T15:28:38+05:30",
+    "processing_method": "",
+    "refunds": [
+
+    ],
+    "shipping_lines": [
+
+    ],
+    "source_name": "488472577",
+    "subtotal_price": "2500.00",
+    "subtotal_price_set": {
+        "shop_money": {
+            "amount": "2500.00",
+            "currency_code": "LKR"
         },
-        "total_line_items_price": "2500.00",
-        "total_line_items_price_set": {
-            "shop_money": {
-                "amount": "2500.00",
-                "currency_code": "LKR"
-            },
-            "presentment_money": {
-                "amount": "2500.00",
-                "currency_code": "LKR"
-            }
+        "presentment_money": {
+            "amount": "2500.00",
+            "currency_code": "LKR"
+        }
+    },
+    "tags": "",
+    "tax_lines": [
+
+    ],
+    "taxes_included": false,
+    "test": false,
+    "token": "03dd268fd532d709a2ae7285fee54e85",
+    "total_discounts": "0.00",
+    "total_discounts_set": {
+        "shop_money": {
+            "amount": "0.00",
+            "currency_code": "LKR"
         },
-        "total_outstanding": "2500.00",
-        "total_price": "2500.00",
-        "total_price_set": {
-            "shop_money": {
-                "amount": "2500.00",
-                "currency_code": "LKR"
-            },
-            "presentment_money": {
-                "amount": "2500.00",
-                "currency_code": "LKR"
-            }
+        "presentment_money": {
+            "amount": "0.00",
+            "currency_code": "LKR"
+        }
+    },
+    "total_line_items_price": "2500.00",
+    "total_line_items_price_set": {
+        "shop_money": {
+            "amount": "2500.00",
+            "currency_code": "LKR"
         },
-        "total_shipping_price_set": {
-            "shop_money": {
-                "amount": "0.00",
-                "currency_code": "LKR"
-            },
-            "presentment_money": {
-                "amount": "0.00",
-                "currency_code": "LKR"
-            }
+        "presentment_money": {
+            "amount": "2500.00",
+            "currency_code": "LKR"
+        }
+    },
+    "total_outstanding": "2500.00",
+    "total_price": "2500.00",
+    "total_price_set": {
+        "shop_money": {
+            "amount": "2500.00",
+            "currency_code": "LKR"
         },
-        "total_tax": "0.00",
-        "total_tax_set": {
-            "shop_money": {
-                "amount": "0.00",
-                "currency_code": "LKR"
-            },
-            "presentment_money": {
-                "amount": "0.00",
-                "currency_code": "LKR"
-            }
+        "presentment_money": {
+            "amount": "2500.00",
+            "currency_code": "LKR"
+        }
+    },
+    "total_shipping_price_set": {
+        "shop_money": {
+            "amount": "0.00",
+            "currency_code": "LKR"
         },
-        "total_tip_received": "0.00",
-        "total_weight": 0d,
-        "updated_at": "2022-06-28T15:28:38+05:30",
-        "order_status_url": "https://zrhtwochak.myshopify.com/64625017083/orders/03dd268fd532d709a2ae7285fee54e85/authenticatekey=704bed3322a51f1f7414cf4c7340ec25",
-        "total_price_usd": "6.96",
-        "confirmed": true,
-        "contact_email": "roland.hewage@gmail.com",
-        "admin_graphql_api_id": "gid://shopify/Order/4797045473531"
-    }
+        "presentment_money": {
+            "amount": "0.00",
+            "currency_code": "LKR"
+        }
+    },
+    "total_tax": "0.00",
+    "total_tax_set": {
+        "shop_money": {
+            "amount": "0.00",
+            "currency_code": "LKR"
+        },
+        "presentment_money": {
+            "amount": "0.00",
+            "currency_code": "LKR"
+        }
+    },
+    "total_tip_received": "0.00",
+    "total_weight": 0d,
+    "updated_at": "2022-06-28T15:28:38+05:30",
+    "order_status_url": "https://zrhtwochak.myshopify.com/64625017083/orders/03dd268fd532d709a2ae7285fee54e85/authenticatekey=704bed3322a51f1f7414cf4c7340ec25",
+    "total_price_usd": "6.96",
+    "confirmed": true,
+    "contact_email": "roland.hewage@gmail.com",
+    "admin_graphql_api_id": "gid://shopify/Order/4797045473531"
 };
 
 @test:Config {}
@@ -342,7 +340,7 @@ isolated function testSampleFailure1() returns error? {
     rec.customer.currency = "INVALID";
     Order|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'length' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.customer.currency=>length' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -354,7 +352,7 @@ isolated function testSampleFailure2() returns error? {
     rec.presentment_currency = "INVALID";
     Order|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'length' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.presentment_currency=>length' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -366,7 +364,7 @@ isolated function testSampleFailure3() returns error? {
     rec.current_total_discounts_set.shop_money.currency_code = "INVALID";
     Order|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'length' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.current_total_discounts_set.shop_money.currency_code=>length' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -378,7 +376,7 @@ isolated function testSampleFailure4() returns error? {
     rec.fulfillments[0].line_items[0].price_set.shop_money.currency_code = "INVALID";
     Order|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'length' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.fulfillments[0].line_items[0].price_set.shop_money.currency_code=>length' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -390,7 +388,7 @@ isolated function testSampleFailure5() returns error? {
     rec.number = -1;
     Order|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.number=>minValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -402,7 +400,7 @@ isolated function testSampleFailure6() returns error? {
     rec.order_number = 1000;
     Order|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.order_number=>minValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -414,7 +412,7 @@ isolated function testSampleFailure7() returns error? {
     rec.customer.orders_count = 0;
     Order|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.customer.orders_count=>minValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -426,7 +424,7 @@ isolated function testSampleFailure8() returns error? {
     rec.fulfillments[0].line_items[0].quantity = -1;
     Order|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.fulfillments[0].line_items[0].quantity=>minValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -438,7 +436,7 @@ isolated function testSampleFailure9() returns error? {
     rec.fulfillments[0].line_items[0].grams = 0;
     Order|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.fulfillments[0].line_items[0].grams=>minValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -450,7 +448,7 @@ isolated function testSampleFailure10() returns error? {
     rec.fulfillments[0].line_items[0].fulfillable_quantity = -1;
     Order|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.fulfillments[0].line_items[0].fulfillable_quantity=>minValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -471,7 +469,17 @@ isolated function testSampleFailure11() returns error? {
     rec.fulfillments[0].line_items[0].fulfillable_quantity = -1;
     Order|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValue','length','minValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for " +
+        "'$.current_total_discounts_set.shop_money.currency_code=>length'," +
+        "'$.customer.currency=>length'," +
+        "'$.customer.orders_count=>minValueExclusive'," +
+        "'$.fulfillments[0].line_items[0].fulfillable_quantity=>minValue'," +
+        "'$.fulfillments[0].line_items[0].grams=>minValueExclusive'," +
+        "'$.fulfillments[0].line_items[0].price_set.shop_money.currency_code=>length'," +
+        "'$.fulfillments[0].line_items[0].quantity=>minValue'," +
+        "'$.number=>minValue'," +
+        "'$.order_number=>minValue'," +
+        "'$.presentment_currency=>length' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }

--- a/ballerina/tests/float_constraint_on_record_field_test.bal
+++ b/ballerina/tests/float_constraint_on_record_field_test.bal
@@ -61,7 +61,7 @@ isolated function testFloatConstraintMinValueOnRecordFieldFailure() {
     FloatConstraintMinValueOnRecordField rec = {value: 16.5};
     FloatConstraintMinValueOnRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>minValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -97,7 +97,7 @@ isolated function testFloatConstraintMaxValueOnRecordFieldFailure() {
     FloatConstraintMaxValueOnRecordField rec = {value: 120.5};
     FloatConstraintMaxValueOnRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>maxValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -124,7 +124,7 @@ isolated function testFloatConstraintMinValueExclusiveOnRecordFieldFailure1() {
     FloatConstraintMinValueExclusiveOnRecordField rec = {value: 18.5};
     FloatConstraintMinValueExclusiveOnRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>minValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -135,7 +135,7 @@ isolated function testFloatConstraintMinValueExclusiveOnRecordFieldFailure2() {
     FloatConstraintMinValueExclusiveOnRecordField rec = {value: 16.5};
     FloatConstraintMinValueExclusiveOnRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>minValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -162,7 +162,7 @@ isolated function testFloatConstraintMaxValueExclusiveOnRecordFieldFailure1() {
     FloatConstraintMaxValueExclusiveOnRecordField rec = {value: 100.5};
     FloatConstraintMaxValueExclusiveOnRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>maxValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -173,7 +173,7 @@ isolated function testFloatConstraintMaxValueExclusiveOnRecordFieldFailure2() {
     FloatConstraintMaxValueExclusiveOnRecordField rec = {value: 120.5};
     FloatConstraintMaxValueExclusiveOnRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>maxValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -219,7 +219,7 @@ isolated function testFloatConstraintOnRecordFieldFailure1() {
     FloatConstraintOnRecordField rec = {value: 16.5};
     FloatConstraintOnRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>minValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -230,7 +230,7 @@ isolated function testFloatConstraintOnRecordFieldFailure2() {
     FloatConstraintOnRecordField rec = {value: 120.5};
     FloatConstraintOnRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>maxValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }

--- a/ballerina/tests/float_constraint_on_record_field_test.bal
+++ b/ballerina/tests/float_constraint_on_record_field_test.bal
@@ -61,7 +61,7 @@ isolated function testFloatConstraintMinValueOnRecordFieldFailure() {
     FloatConstraintMinValueOnRecordField rec = {value: 16.5};
     FloatConstraintMinValueOnRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$.value=>minValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value:minValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -97,7 +97,7 @@ isolated function testFloatConstraintMaxValueOnRecordFieldFailure() {
     FloatConstraintMaxValueOnRecordField rec = {value: 120.5};
     FloatConstraintMaxValueOnRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$.value=>maxValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value:maxValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -124,7 +124,7 @@ isolated function testFloatConstraintMinValueExclusiveOnRecordFieldFailure1() {
     FloatConstraintMinValueExclusiveOnRecordField rec = {value: 18.5};
     FloatConstraintMinValueExclusiveOnRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$.value=>minValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value:minValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -135,7 +135,7 @@ isolated function testFloatConstraintMinValueExclusiveOnRecordFieldFailure2() {
     FloatConstraintMinValueExclusiveOnRecordField rec = {value: 16.5};
     FloatConstraintMinValueExclusiveOnRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$.value=>minValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value:minValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -162,7 +162,7 @@ isolated function testFloatConstraintMaxValueExclusiveOnRecordFieldFailure1() {
     FloatConstraintMaxValueExclusiveOnRecordField rec = {value: 100.5};
     FloatConstraintMaxValueExclusiveOnRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$.value=>maxValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value:maxValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -173,7 +173,7 @@ isolated function testFloatConstraintMaxValueExclusiveOnRecordFieldFailure2() {
     FloatConstraintMaxValueExclusiveOnRecordField rec = {value: 120.5};
     FloatConstraintMaxValueExclusiveOnRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$.value=>maxValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value:maxValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -219,7 +219,7 @@ isolated function testFloatConstraintOnRecordFieldFailure1() {
     FloatConstraintOnRecordField rec = {value: 16.5};
     FloatConstraintOnRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$.value=>minValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value:minValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -230,7 +230,7 @@ isolated function testFloatConstraintOnRecordFieldFailure2() {
     FloatConstraintOnRecordField rec = {value: 120.5};
     FloatConstraintOnRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$.value=>maxValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value:maxValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }

--- a/ballerina/tests/float_constraint_on_type_as_record_field_test.bal
+++ b/ballerina/tests/float_constraint_on_type_as_record_field_test.bal
@@ -58,7 +58,7 @@ isolated function testFloatConstraintMinValueOnTypeAsRecordFieldFailure() {
     FloatConstraintMinValueOnTypeAsRecordField rec = {value: 16.5};
     FloatConstraintMinValueOnTypeAsRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>minValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -91,7 +91,7 @@ isolated function testFloatConstraintMaxValueOnTypeAsRecordFieldFailure() {
     FloatConstraintMaxValueOnTypeAsRecordField rec = {value: 120.5};
     FloatConstraintMaxValueOnTypeAsRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>maxValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -115,7 +115,7 @@ isolated function testFloatConstraintMinValueExclusiveOnTypeAsRecordFieldFailure
     FloatConstraintMinValueExclusiveOnTypeAsRecordField rec = {value: 18.5};
     FloatConstraintMinValueExclusiveOnTypeAsRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>minValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -126,7 +126,7 @@ isolated function testFloatConstraintMinValueExclusiveOnTypeAsRecordFieldFailure
     FloatConstraintMinValueExclusiveOnTypeAsRecordField rec = {value: 16.5};
     FloatConstraintMinValueExclusiveOnTypeAsRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>minValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -150,7 +150,7 @@ isolated function testFloatConstraintMaxValueExclusiveOnTypeAsRecordFieldFailure
     FloatConstraintMaxValueExclusiveOnTypeAsRecordField rec = {value: 100.5};
     FloatConstraintMaxValueExclusiveOnTypeAsRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>maxValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -161,7 +161,7 @@ isolated function testFloatConstraintMaxValueExclusiveOnTypeAsRecordFieldFailure
     FloatConstraintMaxValueExclusiveOnTypeAsRecordField rec = {value: 120.5};
     FloatConstraintMaxValueExclusiveOnTypeAsRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>maxValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -203,7 +203,7 @@ isolated function testFloatConstraintOnTypeAsRecordFieldFailure1() {
     FloatConstraintOnTypeAsRecordField rec = {value: 16.5};
     FloatConstraintOnTypeAsRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>minValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -214,7 +214,7 @@ isolated function testFloatConstraintOnTypeAsRecordFieldFailure2() {
     FloatConstraintOnTypeAsRecordField rec = {value: 120.5};
     FloatConstraintOnTypeAsRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>maxValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }

--- a/ballerina/tests/float_constraint_on_type_test.bal
+++ b/ballerina/tests/float_constraint_on_type_test.bal
@@ -55,7 +55,7 @@ isolated function testFloatConstraintMinValueOnTypeFailure() {
     FloatConstraintMinValueOnType typ = 16.5;
     FloatConstraintMinValueOnType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$=>minValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -89,7 +89,7 @@ isolated function testFloatConstraintMaxValueOnTypeFailure() {
     FloatConstraintMaxValueOnType typ = 120.5;
     FloatConstraintMaxValueOnType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$=>maxValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -114,7 +114,7 @@ isolated function testFloatConstraintMinValueExclusiveOnTypeFailure1() {
     FloatConstraintMinValueExclusiveOnType typ = 18.5;
     FloatConstraintMinValueExclusiveOnType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$=>minValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -125,7 +125,7 @@ isolated function testFloatConstraintMinValueExclusiveOnTypeFailure2() {
     FloatConstraintMinValueExclusiveOnType typ = 16.5;
     FloatConstraintMinValueExclusiveOnType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$=>minValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -152,7 +152,7 @@ isolated function testFloatConstraintMaxValueExclusiveOnTypeFailure1() {
     FloatConstraintMaxValueExclusiveOnType typ = 100.5;
     FloatConstraintMaxValueExclusiveOnType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$=>maxValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -163,7 +163,7 @@ isolated function testFloatConstraintMaxValueExclusiveOnTypeFailure2() {
     FloatConstraintMaxValueExclusiveOnType typ = 120.5;
     FloatConstraintMaxValueExclusiveOnType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$=>maxValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -207,7 +207,7 @@ isolated function testFloatConstraintOnTypeFailure1() {
     FloatConstraintOnType typ = 16.5;
     FloatConstraintOnType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$=>minValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -218,7 +218,7 @@ isolated function testFloatConstraintOnTypeFailure2() {
     FloatConstraintOnType typ = 120.5;
     FloatConstraintOnType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$=>maxValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }

--- a/ballerina/tests/float_constraint_on_type_test.bal
+++ b/ballerina/tests/float_constraint_on_type_test.bal
@@ -55,7 +55,7 @@ isolated function testFloatConstraintMinValueOnTypeFailure() {
     FloatConstraintMinValueOnType typ = 16.5;
     FloatConstraintMinValueOnType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$=>minValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$:minValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -89,7 +89,7 @@ isolated function testFloatConstraintMaxValueOnTypeFailure() {
     FloatConstraintMaxValueOnType typ = 120.5;
     FloatConstraintMaxValueOnType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$=>maxValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$:maxValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -114,7 +114,7 @@ isolated function testFloatConstraintMinValueExclusiveOnTypeFailure1() {
     FloatConstraintMinValueExclusiveOnType typ = 18.5;
     FloatConstraintMinValueExclusiveOnType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$=>minValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$:minValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -125,7 +125,7 @@ isolated function testFloatConstraintMinValueExclusiveOnTypeFailure2() {
     FloatConstraintMinValueExclusiveOnType typ = 16.5;
     FloatConstraintMinValueExclusiveOnType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$=>minValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$:minValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -152,7 +152,7 @@ isolated function testFloatConstraintMaxValueExclusiveOnTypeFailure1() {
     FloatConstraintMaxValueExclusiveOnType typ = 100.5;
     FloatConstraintMaxValueExclusiveOnType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$=>maxValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$:maxValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -163,7 +163,7 @@ isolated function testFloatConstraintMaxValueExclusiveOnTypeFailure2() {
     FloatConstraintMaxValueExclusiveOnType typ = 120.5;
     FloatConstraintMaxValueExclusiveOnType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$=>maxValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$:maxValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -207,7 +207,7 @@ isolated function testFloatConstraintOnTypeFailure1() {
     FloatConstraintOnType typ = 16.5;
     FloatConstraintOnType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$=>minValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$:minValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -218,7 +218,7 @@ isolated function testFloatConstraintOnTypeFailure2() {
     FloatConstraintOnType typ = 120.5;
     FloatConstraintOnType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$=>maxValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$:maxValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }

--- a/ballerina/tests/int_constraint_on_record_field_test.bal
+++ b/ballerina/tests/int_constraint_on_record_field_test.bal
@@ -61,7 +61,7 @@ isolated function testIntConstraintMinValueOnRecordFieldFailure() {
     IntConstraintMinValueOnRecordField rec = {value: 16};
     IntConstraintMinValueOnRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$.value=>minValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value:minValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -97,7 +97,7 @@ isolated function testIntConstraintMaxValueOnRecordFieldFailure() {
     IntConstraintMaxValueOnRecordField rec = {value: 120};
     IntConstraintMaxValueOnRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$.value=>maxValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value:maxValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -124,7 +124,7 @@ isolated function testIntConstraintMinValueExclusiveOnRecordFieldFailure1() {
     IntConstraintMinValueExclusiveOnRecordField rec = {value: 18};
     IntConstraintMinValueExclusiveOnRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$.value=>minValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value:minValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -135,7 +135,7 @@ isolated function testIntConstraintMinValueExclusiveOnRecordFieldFailure2() {
     IntConstraintMinValueExclusiveOnRecordField rec = {value: 16};
     IntConstraintMinValueExclusiveOnRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$.value=>minValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value:minValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -162,7 +162,7 @@ isolated function testIntConstraintMaxValueExclusiveOnRecordFieldFailure1() {
     IntConstraintMaxValueExclusiveOnRecordField rec = {value: 100};
     IntConstraintMaxValueExclusiveOnRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$.value=>maxValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value:maxValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -173,7 +173,7 @@ isolated function testIntConstraintMaxValueExclusiveOnRecordFieldFailure2() {
     IntConstraintMaxValueExclusiveOnRecordField rec = {value: 120};
     IntConstraintMaxValueExclusiveOnRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$.value=>maxValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value:maxValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -219,7 +219,7 @@ isolated function testIntConstraintOnRecordFieldFailure1() {
     IntConstraintOnRecordField rec = {value: 16};
     IntConstraintOnRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$.value=>minValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value:minValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -230,7 +230,7 @@ isolated function testIntConstraintOnRecordFieldFailure2() {
     IntConstraintOnRecordField rec = {value: 120};
     IntConstraintOnRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$.value=>maxValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value:maxValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }

--- a/ballerina/tests/int_constraint_on_record_field_test.bal
+++ b/ballerina/tests/int_constraint_on_record_field_test.bal
@@ -61,7 +61,7 @@ isolated function testIntConstraintMinValueOnRecordFieldFailure() {
     IntConstraintMinValueOnRecordField rec = {value: 16};
     IntConstraintMinValueOnRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>minValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -97,7 +97,7 @@ isolated function testIntConstraintMaxValueOnRecordFieldFailure() {
     IntConstraintMaxValueOnRecordField rec = {value: 120};
     IntConstraintMaxValueOnRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>maxValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -124,7 +124,7 @@ isolated function testIntConstraintMinValueExclusiveOnRecordFieldFailure1() {
     IntConstraintMinValueExclusiveOnRecordField rec = {value: 18};
     IntConstraintMinValueExclusiveOnRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>minValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -135,7 +135,7 @@ isolated function testIntConstraintMinValueExclusiveOnRecordFieldFailure2() {
     IntConstraintMinValueExclusiveOnRecordField rec = {value: 16};
     IntConstraintMinValueExclusiveOnRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>minValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -162,7 +162,7 @@ isolated function testIntConstraintMaxValueExclusiveOnRecordFieldFailure1() {
     IntConstraintMaxValueExclusiveOnRecordField rec = {value: 100};
     IntConstraintMaxValueExclusiveOnRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>maxValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -173,7 +173,7 @@ isolated function testIntConstraintMaxValueExclusiveOnRecordFieldFailure2() {
     IntConstraintMaxValueExclusiveOnRecordField rec = {value: 120};
     IntConstraintMaxValueExclusiveOnRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>maxValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -219,7 +219,7 @@ isolated function testIntConstraintOnRecordFieldFailure1() {
     IntConstraintOnRecordField rec = {value: 16};
     IntConstraintOnRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>minValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -230,7 +230,7 @@ isolated function testIntConstraintOnRecordFieldFailure2() {
     IntConstraintOnRecordField rec = {value: 120};
     IntConstraintOnRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>maxValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }

--- a/ballerina/tests/int_constraint_on_type_as_record_field_test.bal
+++ b/ballerina/tests/int_constraint_on_type_as_record_field_test.bal
@@ -58,7 +58,7 @@ isolated function testIntConstraintMinValueOnTypeAsRecordFieldFailure() {
     IntConstraintMinValueOnTypeAsRecordField rec = {value: 16};
     IntConstraintMinValueOnTypeAsRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$.value=>minValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value:minValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -91,7 +91,7 @@ isolated function testIntConstraintMaxValueOnTypeAsRecordFieldFailure() {
     IntConstraintMaxValueOnTypeAsRecordField rec = {value: 120};
     IntConstraintMaxValueOnTypeAsRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$.value=>maxValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value:maxValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }

--- a/ballerina/tests/int_constraint_on_type_as_record_field_test.bal
+++ b/ballerina/tests/int_constraint_on_type_as_record_field_test.bal
@@ -58,7 +58,7 @@ isolated function testIntConstraintMinValueOnTypeAsRecordFieldFailure() {
     IntConstraintMinValueOnTypeAsRecordField rec = {value: 16};
     IntConstraintMinValueOnTypeAsRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>minValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -91,7 +91,7 @@ isolated function testIntConstraintMaxValueOnTypeAsRecordFieldFailure() {
     IntConstraintMaxValueOnTypeAsRecordField rec = {value: 120};
     IntConstraintMaxValueOnTypeAsRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>maxValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -115,7 +115,7 @@ isolated function testIntConstraintMinValueExclusiveOnTypeAsRecordFieldFailure1(
     IntConstraintMinValueExclusiveOnTypeAsRecordField rec = {value: 18};
     IntConstraintMinValueExclusiveOnTypeAsRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>minValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -126,7 +126,7 @@ isolated function testIntConstraintMinValueExclusiveOnTypeAsRecordFieldFailure2(
     IntConstraintMinValueExclusiveOnTypeAsRecordField rec = {value: 16};
     IntConstraintMinValueExclusiveOnTypeAsRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>minValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -150,7 +150,7 @@ isolated function testIntConstraintMaxValueExclusiveOnTypeAsRecordFieldFailure1(
     IntConstraintMaxValueExclusiveOnTypeAsRecordField rec = {value: 100};
     IntConstraintMaxValueExclusiveOnTypeAsRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>maxValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -161,7 +161,7 @@ isolated function testIntConstraintMaxValueExclusiveOnTypeAsRecordFieldFailure2(
     IntConstraintMaxValueExclusiveOnTypeAsRecordField rec = {value: 120};
     IntConstraintMaxValueExclusiveOnTypeAsRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>maxValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -203,7 +203,7 @@ isolated function testIntConstraintOnTypeAsRecordFieldFailure1() {
     IntConstraintOnTypeAsRecordField rec = {value: 16};
     IntConstraintOnTypeAsRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>minValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -214,7 +214,7 @@ isolated function testIntConstraintOnTypeAsRecordFieldFailure2() {
     IntConstraintOnTypeAsRecordField rec = {value: 120};
     IntConstraintOnTypeAsRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>maxValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }

--- a/ballerina/tests/int_constraint_on_type_test.bal
+++ b/ballerina/tests/int_constraint_on_type_test.bal
@@ -57,7 +57,7 @@ isolated function testIntConstraintMinValueOnTypeFailure() {
     IntConstraintMinValueOnType typ = 16;
     IntConstraintMinValueOnType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$=>minValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -91,7 +91,7 @@ isolated function testIntConstraintMaxValueOnTypeFailure() {
     IntConstraintMaxValueOnType typ = 120;
     IntConstraintMaxValueOnType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$=>maxValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -116,7 +116,7 @@ isolated function testIntConstraintMinValueExclusiveOnTypeFailure1() {
     IntConstraintMinValueExclusiveOnType typ = 18;
     IntConstraintMinValueExclusiveOnType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$=>minValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -127,7 +127,7 @@ isolated function testIntConstraintMinValueExclusiveOnTypeFailure2() {
     IntConstraintMinValueExclusiveOnType typ = 16;
     IntConstraintMinValueExclusiveOnType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$=>minValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -152,7 +152,7 @@ isolated function testIntConstraintMaxValueExclusiveOnTypeFailure1() {
     IntConstraintMaxValueExclusiveOnType typ = 100;
     IntConstraintMaxValueExclusiveOnType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$=>maxValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -163,7 +163,7 @@ isolated function testIntConstraintMaxValueExclusiveOnTypeFailure2() {
     IntConstraintMaxValueExclusiveOnType typ = 120;
     IntConstraintMaxValueExclusiveOnType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$=>maxValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -207,7 +207,7 @@ isolated function testIntConstraintOnTypeFailure1() {
     IntConstraintOnType typ = 16;
     IntConstraintOnType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$=>minValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -218,7 +218,7 @@ isolated function testIntConstraintOnTypeFailure2() {
     IntConstraintOnType typ = 120;
     IntConstraintOnType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$=>maxValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }

--- a/ballerina/tests/int_constraint_on_type_test.bal
+++ b/ballerina/tests/int_constraint_on_type_test.bal
@@ -57,7 +57,7 @@ isolated function testIntConstraintMinValueOnTypeFailure() {
     IntConstraintMinValueOnType typ = 16;
     IntConstraintMinValueOnType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$=>minValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$:minValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -91,7 +91,7 @@ isolated function testIntConstraintMaxValueOnTypeFailure() {
     IntConstraintMaxValueOnType typ = 120;
     IntConstraintMaxValueOnType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$=>maxValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$:maxValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -116,7 +116,7 @@ isolated function testIntConstraintMinValueExclusiveOnTypeFailure1() {
     IntConstraintMinValueExclusiveOnType typ = 18;
     IntConstraintMinValueExclusiveOnType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$=>minValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$:minValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -127,7 +127,7 @@ isolated function testIntConstraintMinValueExclusiveOnTypeFailure2() {
     IntConstraintMinValueExclusiveOnType typ = 16;
     IntConstraintMinValueExclusiveOnType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$=>minValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$:minValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -152,7 +152,7 @@ isolated function testIntConstraintMaxValueExclusiveOnTypeFailure1() {
     IntConstraintMaxValueExclusiveOnType typ = 100;
     IntConstraintMaxValueExclusiveOnType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$=>maxValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$:maxValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -163,7 +163,7 @@ isolated function testIntConstraintMaxValueExclusiveOnTypeFailure2() {
     IntConstraintMaxValueExclusiveOnType typ = 120;
     IntConstraintMaxValueExclusiveOnType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$=>maxValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$:maxValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -207,7 +207,7 @@ isolated function testIntConstraintOnTypeFailure1() {
     IntConstraintOnType typ = 16;
     IntConstraintOnType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$=>minValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$:minValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -218,7 +218,7 @@ isolated function testIntConstraintOnTypeFailure2() {
     IntConstraintOnType typ = 120;
     IntConstraintOnType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$=>maxValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$:maxValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }

--- a/ballerina/tests/number_constraint_on_record_field_test.bal
+++ b/ballerina/tests/number_constraint_on_record_field_test.bal
@@ -69,7 +69,7 @@ isolated function testNumberConstraintMinValueOnRecordFieldFailure1() {
     NumberConstraintMinValueOnRecordField rec = {intValue: 19, floatValue: 20.5, decimalValue: 16.5d};
     NumberConstraintMinValueOnRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.decimalValue=>minValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -80,7 +80,7 @@ isolated function testNumberConstraintMinValueOnRecordFieldFailure2() {
     NumberConstraintMinValueOnRecordField rec = {intValue: 16, floatValue: 16.5, decimalValue: 16.5d};
     NumberConstraintMinValueOnRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.decimalValue=>minValue','$.floatValue=>minValue','$.intValue=>minValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -124,7 +124,7 @@ isolated function testNumberConstraintMaxValueOnRecordFieldFailure1() {
     NumberConstraintMaxValueOnRecordField rec = {intValue: 100, floatValue: 100.5, decimalValue: 120.5d};
     NumberConstraintMaxValueOnRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.decimalValue=>maxValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -135,7 +135,7 @@ isolated function testNumberConstraintMaxValueOnRecordFieldFailure2() {
     NumberConstraintMaxValueOnRecordField rec = {intValue: 120, floatValue: 120.5, decimalValue: 120.5d};
     NumberConstraintMaxValueOnRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.decimalValue=>maxValue','$.floatValue=>maxValue','$.intValue=>maxValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -170,7 +170,7 @@ isolated function testNumberConstraintMinValueExclusiveOnRecordFieldFailure1() {
     NumberConstraintMinValueExclusiveOnRecordField rec = {intValue: 20, floatValue: 18.5, decimalValue: 18.5d};
     NumberConstraintMinValueExclusiveOnRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.decimalValue=>minValueExclusive','$.floatValue=>minValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -181,7 +181,7 @@ isolated function testNumberConstraintMinValueExclusiveOnRecordFieldFailure2() {
     NumberConstraintMinValueExclusiveOnRecordField rec = {intValue: 20, floatValue: 20.5, decimalValue: 16.5d};
     NumberConstraintMinValueExclusiveOnRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.decimalValue=>minValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -192,7 +192,7 @@ isolated function testNumberConstraintMinValueExclusiveOnRecordFieldFailure3() {
     NumberConstraintMinValueExclusiveOnRecordField rec = {intValue: 16, floatValue: 16.5, decimalValue: 16.5d};
     NumberConstraintMinValueExclusiveOnRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.decimalValue=>minValueExclusive','$.floatValue=>minValueExclusive','$.intValue=>minValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -227,7 +227,7 @@ isolated function testNumberConstraintMaxValueExclusiveOnRecordFieldFailure1() {
     NumberConstraintMaxValueExclusiveOnRecordField rec = {intValue: 100, floatValue: 100.5, decimalValue: 100.5d};
     NumberConstraintMaxValueExclusiveOnRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.decimalValue=>maxValueExclusive','$.floatValue=>maxValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -238,7 +238,7 @@ isolated function testNumberConstraintMaxValueExclusiveOnRecordFieldFailure2() {
     NumberConstraintMaxValueExclusiveOnRecordField rec = {intValue: 100, floatValue: 100.5, decimalValue: 120.5d};
     NumberConstraintMaxValueExclusiveOnRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.decimalValue=>maxValueExclusive','$.floatValue=>maxValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -249,7 +249,7 @@ isolated function testNumberConstraintMaxValueExclusiveOnRecordFieldFailure3() {
     NumberConstraintMaxValueExclusiveOnRecordField rec = {intValue: 120, floatValue: 120.5, decimalValue: 120.5d};
     NumberConstraintMaxValueExclusiveOnRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.decimalValue=>maxValueExclusive','$.floatValue=>maxValueExclusive','$.intValue=>maxValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -305,7 +305,7 @@ isolated function testNumberConstraintOnRecordFieldFailure1() {
     NumberConstraintOnRecordField rec = {intValue: 16, floatValue: 16.5, decimalValue: 16.5d};
     NumberConstraintOnRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.decimalValue=>minValue','$.floatValue=>minValue','$.intValue=>minValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -316,7 +316,7 @@ isolated function testNumberConstraintOnRecordFieldFailure2() {
     NumberConstraintOnRecordField rec = {intValue: 120, floatValue: 120.5, decimalValue: 120.5d};
     NumberConstraintOnRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.decimalValue=>maxValue','$.floatValue=>maxValue','$.intValue=>maxValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -327,7 +327,7 @@ isolated function testNumberConstraintOnRecordFieldFailure3() {
     NumberConstraintOnRecordField rec = {intValue: 16, floatValue: 120.5, decimalValue: 16.5d};
     NumberConstraintOnRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValue','maxValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.decimalValue=>minValue','$.floatValue=>maxValue','$.intValue=>minValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -375,7 +375,7 @@ isolated function testNumberConstraintOnUnionRecordFieldFailure1() {
     NumberConstraintOnUnionRecordField rec = {intFloatValue: 16, intDecimalValue: 100, floatDecimalValue: 20.5, intFloatDecimalValue: 100};
     NumberConstraintOnUnionRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.intFloatValue=>minValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -386,7 +386,7 @@ isolated function testNumberConstraintOnUnionRecordFieldFailure2() {
     NumberConstraintOnUnionRecordField rec = {intFloatValue: 20, intDecimalValue: 120, floatDecimalValue: 20.5, intFloatDecimalValue: 100};
     NumberConstraintOnUnionRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.intDecimalValue=>maxValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -397,7 +397,7 @@ isolated function testNumberConstraintOnUnionRecordFieldFailure3() {
     NumberConstraintOnUnionRecordField rec = {intFloatValue: 20, intDecimalValue: 20, floatDecimalValue: 16.5, intFloatDecimalValue: 100};
     NumberConstraintOnUnionRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.floatDecimalValue=>minValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -408,7 +408,7 @@ isolated function testNumberConstraintOnUnionRecordFieldFailure4() {
     NumberConstraintOnUnionRecordField rec = {intFloatValue: 20, intDecimalValue: 20, floatDecimalValue: 20.5, intFloatDecimalValue: 120};
     NumberConstraintOnUnionRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.intFloatDecimalValue=>maxValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -419,7 +419,7 @@ isolated function testNumberConstraintOnUnionRecordFieldFailure5() {
     NumberConstraintOnUnionRecordField rec = {intFloatValue: 16.5, intDecimalValue: 100.5d, floatDecimalValue: 20.5d, intFloatDecimalValue: 99.5d};
     NumberConstraintOnUnionRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.intFloatValue=>minValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -430,7 +430,7 @@ isolated function testNumberConstraintOnUnionRecordFieldFailure6() {
     NumberConstraintOnUnionRecordField rec = {intFloatValue: 20.5, intDecimalValue: 120.5d, floatDecimalValue: 20.5d, intFloatDecimalValue: 99.5d};
     NumberConstraintOnUnionRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.intDecimalValue=>maxValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -441,7 +441,7 @@ isolated function testNumberConstraintOnUnionRecordFieldFailure7() {
     NumberConstraintOnUnionRecordField rec = {intFloatValue: 20.5, intDecimalValue: 100.5d, floatDecimalValue: 18.5d, intFloatDecimalValue: 99.5d};
     NumberConstraintOnUnionRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.floatDecimalValue=>minValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -452,7 +452,7 @@ isolated function testNumberConstraintOnUnionRecordFieldFailure8() {
     NumberConstraintOnUnionRecordField rec = {intFloatValue: 20.5, intDecimalValue: 100.5d, floatDecimalValue: 20.5d, intFloatDecimalValue: 100.5d};
     NumberConstraintOnUnionRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.intFloatDecimalValue=>maxValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }

--- a/ballerina/tests/number_constraint_on_record_field_test.bal
+++ b/ballerina/tests/number_constraint_on_record_field_test.bal
@@ -69,7 +69,7 @@ isolated function testNumberConstraintMinValueOnRecordFieldFailure1() {
     NumberConstraintMinValueOnRecordField rec = {intValue: 19, floatValue: 20.5, decimalValue: 16.5d};
     NumberConstraintMinValueOnRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$.decimalValue=>minValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.decimalValue:minValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }

--- a/ballerina/tests/number_constraint_on_type_as_record_field_test.bal
+++ b/ballerina/tests/number_constraint_on_type_as_record_field_test.bal
@@ -60,7 +60,7 @@ isolated function testNumberConstraintMinValueOnTypeAsRecordFieldFailure1() {
     NumberConstraintMinValueOnTypeAsRecordField rec = {intValue: 19, floatValue: 20.5, decimalValue: 16.5d};
     NumberConstraintMinValueOnTypeAsRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.decimalValue=>minValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -71,7 +71,7 @@ isolated function testNumberConstraintMinValueOnTypeAsRecordFieldFailure2() {
     NumberConstraintMinValueOnTypeAsRecordField rec = {intValue: 16, floatValue: 16.5, decimalValue: 16.5d};
     NumberConstraintMinValueOnTypeAsRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.decimalValue=>minValue','$.floatValue=>minValue','$.intValue=>minValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -106,7 +106,7 @@ isolated function testNumberConstraintMaxValueOnTypeAsRecordFieldFailure1() {
     NumberConstraintMaxValueOnTypeAsRecordField rec = {intValue: 100, floatValue: 100.5, decimalValue: 120.5d};
     NumberConstraintMaxValueOnTypeAsRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.decimalValue=>maxValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -117,7 +117,7 @@ isolated function testNumberConstraintMaxValueOnTypeAsRecordFieldFailure2() {
     NumberConstraintMaxValueOnTypeAsRecordField rec = {intValue: 120, floatValue: 120.5, decimalValue: 120.5d};
     NumberConstraintMaxValueOnTypeAsRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.decimalValue=>maxValue','$.floatValue=>maxValue','$.intValue=>maxValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -143,7 +143,7 @@ isolated function testNumberConstraintMinValueExclusiveOnTypeAsRecordFieldFailur
     NumberConstraintMinValueExclusiveOnTypeAsRecordField rec = {intValue: 20, floatValue: 18.5, decimalValue: 18.5d};
     NumberConstraintMinValueExclusiveOnTypeAsRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.decimalValue=>minValueExclusive','$.floatValue=>minValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -154,7 +154,7 @@ isolated function testNumberConstraintMinValueExclusiveOnTypeAsRecordFieldFailur
     NumberConstraintMinValueExclusiveOnTypeAsRecordField rec = {intValue: 20, floatValue: 20.5, decimalValue: 16.5d};
     NumberConstraintMinValueExclusiveOnTypeAsRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.decimalValue=>minValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -165,7 +165,7 @@ isolated function testNumberConstraintMinValueExclusiveOnTypeAsRecordFieldFailur
     NumberConstraintMinValueExclusiveOnTypeAsRecordField rec = {intValue: 16, floatValue: 16.5, decimalValue: 16.5d};
     NumberConstraintMinValueExclusiveOnTypeAsRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.decimalValue=>minValueExclusive','$.floatValue=>minValueExclusive','$.intValue=>minValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -191,7 +191,7 @@ isolated function testNumberConstraintMaxValueExclusiveOnTypeAsRecordFieldFailur
     NumberConstraintMaxValueExclusiveOnTypeAsRecordField rec = {intValue: 100, floatValue: 100.5, decimalValue: 100.5d};
     NumberConstraintMaxValueExclusiveOnTypeAsRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.decimalValue=>maxValueExclusive','$.floatValue=>maxValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -202,7 +202,7 @@ isolated function testNumberConstraintMaxValueExclusiveOnTypeAsRecordFieldFailur
     NumberConstraintMaxValueExclusiveOnTypeAsRecordField rec = {intValue: 100, floatValue: 100.5, decimalValue: 120.5d};
     NumberConstraintMaxValueExclusiveOnTypeAsRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.decimalValue=>maxValueExclusive','$.floatValue=>maxValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -213,7 +213,7 @@ isolated function testNumberConstraintMaxValueExclusiveOnTypeAsRecordFieldFailur
     NumberConstraintMaxValueExclusiveOnTypeAsRecordField rec = {intValue: 120, floatValue: 120.5, decimalValue: 120.5d};
     NumberConstraintMaxValueExclusiveOnTypeAsRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.decimalValue=>maxValueExclusive','$.floatValue=>maxValueExclusive','$.intValue=>maxValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -257,7 +257,7 @@ isolated function testNumberConstraintOnTypeAsRecordFieldFailure1() {
     NumberConstraintOnTypeAsRecordField rec = {intValue: 16, floatValue: 16.5, decimalValue: 16.5d};
     NumberConstraintOnTypeAsRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.decimalValue=>minValue','$.floatValue=>minValue','$.intValue=>minValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -268,7 +268,7 @@ isolated function testNumberConstraintOnTypeAsRecordFieldFailure2() {
     NumberConstraintOnTypeAsRecordField rec = {intValue: 120, floatValue: 120.5, decimalValue: 120.5d};
     NumberConstraintOnTypeAsRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.decimalValue=>maxValue','$.floatValue=>maxValue','$.intValue=>maxValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -279,7 +279,7 @@ isolated function testNumberConstraintOnTypeAsRecordFieldFailure3() {
     NumberConstraintOnTypeAsRecordField rec = {intValue: 16, floatValue: 120.5, decimalValue: 16.5d};
     NumberConstraintOnTypeAsRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValue','maxValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.decimalValue=>minValue','$.floatValue=>maxValue','$.intValue=>minValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -317,7 +317,7 @@ isolated function testNumberConstraintOnUnionTypeAsRecordFieldFailure1() {
     NumberConstraintOnUnionTypeAsRecordField rec = {intFloatValue: 16, intDecimalValue: 100, floatDecimalValue: 20.5, intFloatDecimalValue: 100};
     NumberConstraintOnUnionTypeAsRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>minValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -328,7 +328,7 @@ isolated function testNumberConstraintOnUnionTypeAsRecordFieldFailure2() {
     NumberConstraintOnUnionTypeAsRecordField rec = {intFloatValue: 20, intDecimalValue: 120, floatDecimalValue: 20.5, intFloatDecimalValue: 100};
     NumberConstraintOnUnionTypeAsRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>maxValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -339,7 +339,7 @@ isolated function testNumberConstraintOnUnionTypeAsRecordFieldFailure3() {
     NumberConstraintOnUnionTypeAsRecordField rec = {intFloatValue: 20, intDecimalValue: 20, floatDecimalValue: 16.5, intFloatDecimalValue: 100};
     NumberConstraintOnUnionTypeAsRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>minValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -350,7 +350,7 @@ isolated function testNumberConstraintOnUnionTypeAsRecordFieldFailure4() {
     NumberConstraintOnUnionTypeAsRecordField rec = {intFloatValue: 20, intDecimalValue: 20, floatDecimalValue: 20.5, intFloatDecimalValue: 120};
     NumberConstraintOnUnionTypeAsRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>maxValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -361,7 +361,7 @@ isolated function testNumberConstraintOnUnionTypeAsRecordFieldFailure5() {
     NumberConstraintOnUnionTypeAsRecordField rec = {intFloatValue: 16.5, intDecimalValue: 100.5d, floatDecimalValue: 20.5d, intFloatDecimalValue: 99.5d};
     NumberConstraintOnUnionTypeAsRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>minValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -372,7 +372,7 @@ isolated function testNumberConstraintOnUnionTypeAsRecordFieldFailure6() {
     NumberConstraintOnUnionTypeAsRecordField rec = {intFloatValue: 20.5, intDecimalValue: 120.5d, floatDecimalValue: 20.5d, intFloatDecimalValue: 99.5d};
     NumberConstraintOnUnionTypeAsRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>maxValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -383,7 +383,7 @@ isolated function testNumberConstraintOnUnionTypeAsRecordFieldFailure7() {
     NumberConstraintOnUnionTypeAsRecordField rec = {intFloatValue: 20.5, intDecimalValue: 100.5d, floatDecimalValue: 18.5d, intFloatDecimalValue: 99.5d};
     NumberConstraintOnUnionTypeAsRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>minValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -394,7 +394,7 @@ isolated function testNumberConstraintOnUnionTypeAsRecordFieldFailure8() {
     NumberConstraintOnUnionTypeAsRecordField rec = {intFloatValue: 20.5, intDecimalValue: 100.5d, floatDecimalValue: 20.5d, intFloatDecimalValue: 100.5d};
     NumberConstraintOnUnionTypeAsRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>maxValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }

--- a/ballerina/tests/number_constraint_on_type_test.bal
+++ b/ballerina/tests/number_constraint_on_type_test.bal
@@ -87,7 +87,7 @@ isolated function testNumberConstraintMinValueOnTypeFailure1() {
     NumberConstraintMinValueOnIntType typ = 18;
     NumberConstraintMinValueOnIntType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$=>minValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$:minValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -98,7 +98,7 @@ isolated function testNumberConstraintMinValueOnTypeFailure2() {
     NumberConstraintMinValueOnFloatType typ = 16.5;
     NumberConstraintMinValueOnFloatType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$=>minValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$:minValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -109,7 +109,7 @@ isolated function testNumberConstraintMinValueOnTypeFailure3() {
     NumberConstraintMinValueOnDecimalType typ = 16.5d;
     NumberConstraintMinValueOnDecimalType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$=>minValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$:minValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -173,7 +173,7 @@ isolated function testNumberConstraintMaxValueOnTypeFailure1() {
     NumberConstraintMaxValueOnIntType typ = 101;
     NumberConstraintMaxValueOnIntType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$=>maxValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$:maxValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -184,7 +184,7 @@ isolated function testNumberConstraintMaxValueOnTypeFailure2() {
     NumberConstraintMaxValueOnFloatType typ = 101;
     NumberConstraintMaxValueOnFloatType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$=>maxValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$:maxValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -195,7 +195,7 @@ isolated function testNumberConstraintMaxValueOnTypeFailure3() {
     NumberConstraintMaxValueOnDecimalType typ = 101;
     NumberConstraintMaxValueOnDecimalType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$=>maxValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$:maxValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -240,7 +240,7 @@ isolated function testNumberConstraintMinValueExclusiveOnTypeFailure1() {
     NumberConstraintMinValueExclusiveOnIntType typ = 18;
     NumberConstraintMinValueExclusiveOnIntType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$=>minValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$:minValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -251,7 +251,7 @@ isolated function testNumberConstraintMinValueExclusiveOnTypeFailure2() {
     NumberConstraintMinValueExclusiveOnFloatType typ = 18.5;
     NumberConstraintMinValueExclusiveOnFloatType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$=>minValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$:minValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -262,7 +262,7 @@ isolated function testNumberConstraintMinValueExclusiveOnTypeFailure3() {
     NumberConstraintMinValueExclusiveOnDecimalType typ = 18.5d;
     NumberConstraintMinValueExclusiveOnDecimalType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$=>minValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$:minValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -307,7 +307,7 @@ isolated function testNumberConstraintMaxValueExclusiveOnTypeFailure1() {
     NumberConstraintMaxValueExclusiveOnIntType typ = 101;
     NumberConstraintMaxValueExclusiveOnIntType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$=>maxValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$:maxValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -318,7 +318,7 @@ isolated function testNumberConstraintMaxValueExclusiveOnTypeFailure2() {
     NumberConstraintMaxValueExclusiveOnFloatType typ = 100.5;
     NumberConstraintMaxValueExclusiveOnFloatType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$=>maxValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$:maxValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -329,7 +329,7 @@ isolated function testNumberConstraintMaxValueExclusiveOnTypeFailure3() {
     NumberConstraintMaxValueExclusiveOnDecimalType typ = 100.5d;
     NumberConstraintMaxValueExclusiveOnDecimalType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$=>maxValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$:maxValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -415,7 +415,7 @@ isolated function testNumberConstraintOnTypeFailure1() {
     NumberConstraintOnIntType typ = 18;
     NumberConstraintOnIntType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$=>minValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$:minValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -426,7 +426,7 @@ isolated function testNumberConstraintOnTypeFailure2() {
     NumberConstraintOnFloatType typ = 16.5;
     NumberConstraintOnFloatType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$=>minValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$:minValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -437,7 +437,7 @@ isolated function testNumberConstraintOnTypeFailure3() {
     NumberConstraintOnDecimalType typ = 16.5d;
     NumberConstraintOnDecimalType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$=>minValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$:minValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -448,7 +448,7 @@ isolated function testNumberConstraintOnTypeFailure4() {
     NumberConstraintOnIntType typ = 101;
     NumberConstraintOnIntType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$=>maxValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$:maxValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -459,7 +459,7 @@ isolated function testNumberConstraintOnTypeFailure5() {
     NumberConstraintOnFloatType typ = 101.5;
     NumberConstraintOnFloatType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$=>maxValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$:maxValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -470,7 +470,7 @@ isolated function testNumberConstraintOnTypeFailure6() {
     NumberConstraintOnDecimalType typ = 101.5d;
     NumberConstraintOnDecimalType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$=>maxValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$:maxValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }

--- a/ballerina/tests/number_constraint_on_type_test.bal
+++ b/ballerina/tests/number_constraint_on_type_test.bal
@@ -87,7 +87,7 @@ isolated function testNumberConstraintMinValueOnTypeFailure1() {
     NumberConstraintMinValueOnIntType typ = 18;
     NumberConstraintMinValueOnIntType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$=>minValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -98,7 +98,7 @@ isolated function testNumberConstraintMinValueOnTypeFailure2() {
     NumberConstraintMinValueOnFloatType typ = 16.5;
     NumberConstraintMinValueOnFloatType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$=>minValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -109,7 +109,7 @@ isolated function testNumberConstraintMinValueOnTypeFailure3() {
     NumberConstraintMinValueOnDecimalType typ = 16.5d;
     NumberConstraintMinValueOnDecimalType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$=>minValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -173,7 +173,7 @@ isolated function testNumberConstraintMaxValueOnTypeFailure1() {
     NumberConstraintMaxValueOnIntType typ = 101;
     NumberConstraintMaxValueOnIntType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$=>maxValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -184,7 +184,7 @@ isolated function testNumberConstraintMaxValueOnTypeFailure2() {
     NumberConstraintMaxValueOnFloatType typ = 101;
     NumberConstraintMaxValueOnFloatType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$=>maxValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -195,7 +195,7 @@ isolated function testNumberConstraintMaxValueOnTypeFailure3() {
     NumberConstraintMaxValueOnDecimalType typ = 101;
     NumberConstraintMaxValueOnDecimalType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$=>maxValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -240,7 +240,7 @@ isolated function testNumberConstraintMinValueExclusiveOnTypeFailure1() {
     NumberConstraintMinValueExclusiveOnIntType typ = 18;
     NumberConstraintMinValueExclusiveOnIntType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$=>minValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -251,7 +251,7 @@ isolated function testNumberConstraintMinValueExclusiveOnTypeFailure2() {
     NumberConstraintMinValueExclusiveOnFloatType typ = 18.5;
     NumberConstraintMinValueExclusiveOnFloatType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$=>minValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -262,7 +262,7 @@ isolated function testNumberConstraintMinValueExclusiveOnTypeFailure3() {
     NumberConstraintMinValueExclusiveOnDecimalType typ = 18.5d;
     NumberConstraintMinValueExclusiveOnDecimalType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$=>minValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -307,7 +307,7 @@ isolated function testNumberConstraintMaxValueExclusiveOnTypeFailure1() {
     NumberConstraintMaxValueExclusiveOnIntType typ = 101;
     NumberConstraintMaxValueExclusiveOnIntType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$=>maxValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -318,7 +318,7 @@ isolated function testNumberConstraintMaxValueExclusiveOnTypeFailure2() {
     NumberConstraintMaxValueExclusiveOnFloatType typ = 100.5;
     NumberConstraintMaxValueExclusiveOnFloatType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$=>maxValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -329,7 +329,7 @@ isolated function testNumberConstraintMaxValueExclusiveOnTypeFailure3() {
     NumberConstraintMaxValueExclusiveOnDecimalType typ = 100.5d;
     NumberConstraintMaxValueExclusiveOnDecimalType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$=>maxValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -415,7 +415,7 @@ isolated function testNumberConstraintOnTypeFailure1() {
     NumberConstraintOnIntType typ = 18;
     NumberConstraintOnIntType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$=>minValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -426,7 +426,7 @@ isolated function testNumberConstraintOnTypeFailure2() {
     NumberConstraintOnFloatType typ = 16.5;
     NumberConstraintOnFloatType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$=>minValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -437,7 +437,7 @@ isolated function testNumberConstraintOnTypeFailure3() {
     NumberConstraintOnDecimalType typ = 16.5d;
     NumberConstraintOnDecimalType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$=>minValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -448,7 +448,7 @@ isolated function testNumberConstraintOnTypeFailure4() {
     NumberConstraintOnIntType typ = 101;
     NumberConstraintOnIntType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$=>maxValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -459,7 +459,7 @@ isolated function testNumberConstraintOnTypeFailure5() {
     NumberConstraintOnFloatType typ = 101.5;
     NumberConstraintOnFloatType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$=>maxValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -470,7 +470,7 @@ isolated function testNumberConstraintOnTypeFailure6() {
     NumberConstraintOnDecimalType typ = 101.5d;
     NumberConstraintOnDecimalType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$=>maxValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -551,7 +551,7 @@ isolated function testNumberConstraintOnUnionTypeFailure1() {
     NumberConstraintOnUnionIntFloatType typ = 16;
     NumberConstraintOnUnionIntFloatType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$=>minValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -562,7 +562,7 @@ isolated function testNumberConstraintOnUnionTypeFailure2() {
     NumberConstraintOnUnionIntDecimalType typ = 120;
     NumberConstraintOnUnionIntFloatType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$=>maxValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -573,7 +573,7 @@ isolated function testNumberConstraintOnUnionTypeFailure3() {
     NumberConstraintOnUnionFloatDecimalType typ = 16.5;
     NumberConstraintOnUnionIntFloatType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$=>minValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -584,7 +584,7 @@ isolated function testNumberConstraintOnUnionTypeFailure4() {
     NumberConstraintOnUnionIntFloatDecimalType typ = 120;
     NumberConstraintOnUnionIntFloatType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$=>maxValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -595,7 +595,7 @@ isolated function testNumberConstraintOnUnionTypeFailure5() {
     NumberConstraintOnUnionIntFloatType typ = 16.5;
     NumberConstraintOnUnionIntFloatType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$=>minValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -606,7 +606,7 @@ isolated function testNumberConstraintOnUnionTypeFailure6() {
     NumberConstraintOnUnionIntDecimalType typ = 120.5d;
     NumberConstraintOnUnionIntFloatType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxValue' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$=>maxValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -617,7 +617,7 @@ isolated function testNumberConstraintOnUnionTypeFailure7() {
     NumberConstraintOnUnionFloatDecimalType typ = 18.5d;
     NumberConstraintOnUnionIntFloatType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$=>minValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -628,7 +628,7 @@ isolated function testNumberConstraintOnUnionTypeFailure8() {
     NumberConstraintOnUnionIntFloatDecimalType typ = 100.5d;
     NumberConstraintOnUnionIntFloatType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxValueExclusive' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$=>maxValueExclusive' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }

--- a/ballerina/tests/string_constraint_on_record_field_test.bal
+++ b/ballerina/tests/string_constraint_on_record_field_test.bal
@@ -52,7 +52,7 @@ isolated function testStringConstraintLengthOnRecordFieldFailure1() {
     StringConstraintLengthOnRecordField rec = {value: "s3cr3t1"};
     StringConstraintLengthOnRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$.value=>length' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value:length' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -63,7 +63,7 @@ isolated function testStringConstraintLengthOnRecordFieldFailure2() {
     StringConstraintLengthOnRecordField rec = {value: "s3cr3"};
     StringConstraintLengthOnRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$.value=>length' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value:length' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -99,7 +99,7 @@ isolated function testStringConstraintMinLengthOnRecordFieldFailure() {
     StringConstraintMinLengthOnRecordField rec = {value: "s3c"};
     StringConstraintMinLengthOnRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$.value=>minLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value:minLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -135,7 +135,7 @@ isolated function testStringConstraintMaxLengthOnRecordFieldFailure() {
     StringConstraintMaxLengthOnRecordField rec = {value: "s3cr3ts"};
     StringConstraintMaxLengthOnRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$.value=>maxLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value:maxLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }

--- a/ballerina/tests/string_constraint_on_record_field_test.bal
+++ b/ballerina/tests/string_constraint_on_record_field_test.bal
@@ -52,7 +52,7 @@ isolated function testStringConstraintLengthOnRecordFieldFailure1() {
     StringConstraintLengthOnRecordField rec = {value: "s3cr3t1"};
     StringConstraintLengthOnRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'length' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>length' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -63,7 +63,7 @@ isolated function testStringConstraintLengthOnRecordFieldFailure2() {
     StringConstraintLengthOnRecordField rec = {value: "s3cr3"};
     StringConstraintLengthOnRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'length' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>length' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -99,7 +99,7 @@ isolated function testStringConstraintMinLengthOnRecordFieldFailure() {
     StringConstraintMinLengthOnRecordField rec = {value: "s3c"};
     StringConstraintMinLengthOnRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>minLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -135,7 +135,7 @@ isolated function testStringConstraintMaxLengthOnRecordFieldFailure() {
     StringConstraintMaxLengthOnRecordField rec = {value: "s3cr3ts"};
     StringConstraintMaxLengthOnRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>maxLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -181,7 +181,7 @@ isolated function testStringConstraintOnRecordFieldFailure1() {
     StringConstraintOnRecordField rec = {value: "s3crt"};
     StringConstraintOnRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>minLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -192,7 +192,7 @@ isolated function testStringConstraintOnRecordFieldFailure2() {
     StringConstraintOnRecordField rec = {value: "s3cr3ts3cr3ts3cr3t"};
     StringConstraintOnRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>maxLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }

--- a/ballerina/tests/string_constraint_on_type_as_record_field_test.bal
+++ b/ballerina/tests/string_constraint_on_type_as_record_field_test.bal
@@ -49,7 +49,7 @@ isolated function testStringConstraintLengthOnTypeAsRecordFieldFailure1() {
     StringConstraintLengthOnTypeAsRecordField rec = {value: "s3cr3t1"};
     StringConstraintLengthOnTypeAsRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'length' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>length' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -60,7 +60,7 @@ isolated function testStringConstraintLengthOnTypeAsRecordFieldFailure2() {
     StringConstraintLengthOnTypeAsRecordField rec = {value: "s3cr3"};
     StringConstraintLengthOnTypeAsRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'length' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>length' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -93,7 +93,7 @@ isolated function testStringConstraintMinLengthOnTypeAsRecordFieldFailure() {
     StringConstraintMinLengthOnTypeAsRecordField rec = {value: "s3c"};
     StringConstraintMinLengthOnTypeAsRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>minLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -126,7 +126,7 @@ isolated function testStringConstraintMaxLengthOnTypeAsRecordFieldFailure() {
     StringConstraintMaxLengthOnTypeAsRecordField rec = {value: "s3cr3ts"};
     StringConstraintMaxLengthOnTypeAsRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>maxLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -168,7 +168,7 @@ isolated function testStringConstraintOnTypeAsRecordFieldFailure1() {
     StringConstraintOnTypeAsRecordField rec = {value: "s3crt"};
     StringConstraintOnTypeAsRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>minLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -179,7 +179,7 @@ isolated function testStringConstraintOnTypeAsRecordFieldFailure2() {
     StringConstraintOnTypeAsRecordField rec = {value: "s3cr3ts3cr3ts3cr3t"};
     StringConstraintOnTypeAsRecordField|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$.value=>maxLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }

--- a/ballerina/tests/string_constraint_on_type_test.bal
+++ b/ballerina/tests/string_constraint_on_type_test.bal
@@ -48,7 +48,7 @@ isolated function testStringConstraintLengthOnTypeFailure1() {
     StringConstraintLengthOnType typ = "s3cr3t1";
     StringConstraintLengthOnType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$=>length' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$:length' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -59,7 +59,7 @@ isolated function testStringConstraintLengthOnTypeFailure2() {
     StringConstraintLengthOnType typ = "s3cr3";
     StringConstraintLengthOnType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$=>length' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$:length' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -93,7 +93,7 @@ isolated function testStringConstraintMinLengthOnTypeFailure() {
     StringConstraintMinLengthOnType typ = "s3c";
     StringConstraintMinLengthOnType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$=>minLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$:minLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -127,7 +127,7 @@ isolated function testStringConstraintMaxLengthOnTypeFailure() {
     StringConstraintMaxLengthOnType typ = "s3cr3ts";
     StringConstraintMaxLengthOnType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$=>maxLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$:maxLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -171,7 +171,7 @@ isolated function testStringConstraintOnTypeFailure1() {
     StringConstraintOnType typ = "s3crt";
     StringConstraintOnType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$=>minLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$:minLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -182,7 +182,7 @@ isolated function testStringConstraintOnTypeFailure2() {
     StringConstraintOnType typ = "s3cr3ts3cr3ts3cr3t";
     StringConstraintOnType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$=>maxLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$:maxLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }

--- a/ballerina/tests/string_constraint_on_type_test.bal
+++ b/ballerina/tests/string_constraint_on_type_test.bal
@@ -48,7 +48,7 @@ isolated function testStringConstraintLengthOnTypeFailure1() {
     StringConstraintLengthOnType typ = "s3cr3t1";
     StringConstraintLengthOnType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'length' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$=>length' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -59,7 +59,7 @@ isolated function testStringConstraintLengthOnTypeFailure2() {
     StringConstraintLengthOnType typ = "s3cr3";
     StringConstraintLengthOnType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'length' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$=>length' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -93,7 +93,7 @@ isolated function testStringConstraintMinLengthOnTypeFailure() {
     StringConstraintMinLengthOnType typ = "s3c";
     StringConstraintMinLengthOnType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$=>minLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -127,7 +127,7 @@ isolated function testStringConstraintMaxLengthOnTypeFailure() {
     StringConstraintMaxLengthOnType typ = "s3cr3ts";
     StringConstraintMaxLengthOnType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$=>maxLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -171,7 +171,7 @@ isolated function testStringConstraintOnTypeFailure1() {
     StringConstraintOnType typ = "s3crt";
     StringConstraintOnType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'minLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$=>minLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -182,7 +182,7 @@ isolated function testStringConstraintOnTypeFailure2() {
     StringConstraintOnType typ = "s3cr3ts3cr3ts3cr3t";
     StringConstraintOnType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for 'maxLength' constraint(s).");
+        test:assertEquals(validation.message(), "Validation failed for '$=>maxLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Implement Ballerina Constraint Package - Phase 1](https://github.com/ballerina-platform/ballerina-standard-library/issues/2861)
 - [Publish the constraint native API](https://github.com/ballerina-platform/ballerina-standard-library/issues/3109)
 - [Add support for constraint validation on union typedesc](https://github.com/ballerina-platform/ballerina-standard-library/issues/3130)
+- [Improve constraint error message as JsonPath expression](https://github.com/ballerina-platform/ballerina-standard-library/issues/3143)
 
 ### Fixed
 - [Passing the typedesc as a param to the constraint() method returns () in success case ](https://github.com/ballerina-platform/ballerina-standard-library/issues/3107)

--- a/native/src/main/java/io/ballerina/stdlib/constraint/Constants.java
+++ b/native/src/main/java/io/ballerina/stdlib/constraint/Constants.java
@@ -32,7 +32,7 @@ public class Constants {
     public static final String SYMBOL_COMMA = ",";
     public static final String SYMBOL_OPEN_SQUARE_BRACKET = "[";
     public static final String SYMBOL_CLOSE_SQUARE_BRACKET = "]";
-    public static final String SYMBOL_ARROW = "=>";
+    public static final String SYMBOL_SEPERATOR = ":";
 
     public static final String ANNOTATION_TAG_INT = "Int";
     public static final String ANNOTATION_TAG_FLOAT = "Float";

--- a/native/src/main/java/io/ballerina/stdlib/constraint/Constants.java
+++ b/native/src/main/java/io/ballerina/stdlib/constraint/Constants.java
@@ -32,7 +32,7 @@ public class Constants {
     public static final String SYMBOL_COMMA = ",";
     public static final String SYMBOL_OPEN_SQUARE_BRACKET = "[";
     public static final String SYMBOL_CLOSE_SQUARE_BRACKET = "]";
-    public static final String SYMBOL_SEPERATOR = ":";
+    public static final String SYMBOL_SEPARATOR = ":";
 
     public static final String ANNOTATION_TAG_INT = "Int";
     public static final String ANNOTATION_TAG_FLOAT = "Float";

--- a/native/src/main/java/io/ballerina/stdlib/constraint/Constants.java
+++ b/native/src/main/java/io/ballerina/stdlib/constraint/Constants.java
@@ -26,6 +26,14 @@ public class Constants {
     public static final String PREFIX_RECORD_FILED = "$field$";
     public static final String PREFIX_ANNOTATION_RECORD = "ballerina/constraint:1:";
 
+    public static final String SYMBOL_DOLLAR_SIGN = "$";
+    public static final String SYMBOL_DOT = ".";
+    public static final String SYMBOL_SINGLE_QUOTE = "'";
+    public static final String SYMBOL_COMMA = ",";
+    public static final String SYMBOL_OPEN_SQUARE_BRACKET = "[";
+    public static final String SYMBOL_CLOSE_SQUARE_BRACKET = "]";
+    public static final String SYMBOL_ARROW = "=>";
+
     public static final String ANNOTATION_TAG_INT = "Int";
     public static final String ANNOTATION_TAG_FLOAT = "Float";
     public static final String ANNOTATION_TAG_NUMBER = "Number";

--- a/native/src/main/java/io/ballerina/stdlib/constraint/Constraints.java
+++ b/native/src/main/java/io/ballerina/stdlib/constraint/Constraints.java
@@ -26,8 +26,8 @@ import io.ballerina.stdlib.constraint.annotations.AbstractAnnotations;
 import io.ballerina.stdlib.constraint.annotations.RecordFieldAnnotations;
 import io.ballerina.stdlib.constraint.annotations.TypeAnnotations;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Extern functions for validating constraints.
@@ -35,12 +35,12 @@ import java.util.Set;
 public class Constraints {
 
     public static Object validate(Object value, BTypedesc typedesc) {
-        HashSet<String> failedConstraints = new HashSet<>();
+        List<String> failedConstraints = new ArrayList<>();
         try {
             Type type = typedesc.getDescribingType();
             if (type instanceof AnnotatableType) {
                 AbstractAnnotations annotations = getAnnotationImpl(type, failedConstraints);
-                annotations.validate(value, (AnnotatableType) type);
+                annotations.validate(value, (AnnotatableType) type, Constants.SYMBOL_DOLLAR_SIGN);
             }
             if (!failedConstraints.isEmpty()) {
                 return ErrorUtils.buildValidationError(failedConstraints);
@@ -51,7 +51,7 @@ public class Constraints {
         }
     }
 
-    private static AbstractAnnotations getAnnotationImpl(Type type, Set<String> failedConstraints) {
+    private static AbstractAnnotations getAnnotationImpl(Type type, List<String> failedConstraints) {
         if (type instanceof RecordType) {
             return new RecordFieldAnnotations(failedConstraints);
         } else {

--- a/native/src/main/java/io/ballerina/stdlib/constraint/Constraints.java
+++ b/native/src/main/java/io/ballerina/stdlib/constraint/Constraints.java
@@ -34,6 +34,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import static io.ballerina.stdlib.constraint.Constants.SYMBOL_DOLLAR_SIGN;
+
 /**
  * Extern functions for validating constraints.
  */
@@ -45,7 +47,7 @@ public class Constraints {
             Type type = typedesc.getDescribingType();
             if (type instanceof AnnotatableType) {
                 AbstractAnnotations annotations = getAnnotationImpl(type, failedConstraints);
-                annotations.validate(value, (AnnotatableType) type, Constants.SYMBOL_DOLLAR_SIGN);
+                annotations.validate(value, (AnnotatableType) type, SYMBOL_DOLLAR_SIGN);
             } else if (type instanceof UnionType) {
                 Optional<Type> matchingType = getMatchingType(value, type);
                 if (matchingType.isPresent()) {

--- a/native/src/main/java/io/ballerina/stdlib/constraint/ErrorUtils.java
+++ b/native/src/main/java/io/ballerina/stdlib/constraint/ErrorUtils.java
@@ -22,7 +22,8 @@ import io.ballerina.runtime.api.creators.ErrorCreator;
 import io.ballerina.runtime.api.utils.StringUtils;
 import io.ballerina.runtime.api.values.BError;
 
-import java.util.Set;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Utility functions related to errors.
@@ -37,10 +38,12 @@ public class ErrorUtils {
         return createError(UNEXPECTED_ERROR_MESSAGE);
     }
 
-    static BError buildValidationError(Set<String> failedConstraints) {
+    static BError buildValidationError(List<String> failedConstraints) {
+        Collections.sort(failedConstraints);
         StringBuilder errorMsg = new StringBuilder(VALIDATION_ERROR_MESSAGE_PREFIX);
         for (String constraint : failedConstraints) {
-            errorMsg.append("'").append(constraint).append("',");
+            errorMsg.append(Constants.SYMBOL_SINGLE_QUOTE).
+                    append(constraint).append(Constants.SYMBOL_SINGLE_QUOTE + Constants.SYMBOL_COMMA);
         }
         errorMsg.deleteCharAt(errorMsg.length() - 1);
         errorMsg.append(VALIDATION_ERROR_MESSAGE_SUFFIX);

--- a/native/src/main/java/io/ballerina/stdlib/constraint/ErrorUtils.java
+++ b/native/src/main/java/io/ballerina/stdlib/constraint/ErrorUtils.java
@@ -25,6 +25,10 @@ import io.ballerina.runtime.api.values.BError;
 import java.util.Collections;
 import java.util.List;
 
+import static io.ballerina.stdlib.constraint.Constants.CONSTRAINT_ERROR;
+import static io.ballerina.stdlib.constraint.Constants.SYMBOL_COMMA;
+import static io.ballerina.stdlib.constraint.Constants.SYMBOL_SINGLE_QUOTE;
+
 /**
  * Utility functions related to errors.
  */
@@ -42,8 +46,7 @@ public class ErrorUtils {
         Collections.sort(failedConstraints);
         StringBuilder errorMsg = new StringBuilder(VALIDATION_ERROR_MESSAGE_PREFIX);
         for (String constraint : failedConstraints) {
-            errorMsg.append(Constants.SYMBOL_SINGLE_QUOTE).
-                    append(constraint).append(Constants.SYMBOL_SINGLE_QUOTE + Constants.SYMBOL_COMMA);
+            errorMsg.append(SYMBOL_SINGLE_QUOTE).append(constraint).append(SYMBOL_SINGLE_QUOTE + SYMBOL_COMMA);
         }
         errorMsg.deleteCharAt(errorMsg.length() - 1);
         errorMsg.append(VALIDATION_ERROR_MESSAGE_SUFFIX);
@@ -51,7 +54,7 @@ public class ErrorUtils {
     }
 
     private static BError createError(String errMessage) {
-        return ErrorCreator.createError(ModuleUtils.getModule(), Constants.CONSTRAINT_ERROR,
+        return ErrorCreator.createError(ModuleUtils.getModule(), CONSTRAINT_ERROR,
                 StringUtils.fromString(errMessage), null, null);
     }
 }

--- a/native/src/main/java/io/ballerina/stdlib/constraint/annotations/AbstractAnnotations.java
+++ b/native/src/main/java/io/ballerina/stdlib/constraint/annotations/AbstractAnnotations.java
@@ -28,8 +28,8 @@ import io.ballerina.stdlib.constraint.validators.IntConstraintValidator;
 import io.ballerina.stdlib.constraint.validators.NumberConstraintValidator;
 import io.ballerina.stdlib.constraint.validators.StringConstraintValidator;
 
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * The abstract class to represent the annotation attachment points.
@@ -42,7 +42,7 @@ public abstract class AbstractAnnotations {
     private final StringConstraintValidator stringConstraintValidator;
     private final ArrayConstraintValidator arrayConstraintValidator;
 
-    public AbstractAnnotations(Set<String> failedConstraints) {
+    public AbstractAnnotations(List<String> failedConstraints) {
         this.intConstraintValidator = new IntConstraintValidator(failedConstraints);
         this.floatConstraintValidator = new FloatConstraintValidator(failedConstraints);
         this.numberConstraintValidator = new NumberConstraintValidator(failedConstraints);
@@ -50,34 +50,35 @@ public abstract class AbstractAnnotations {
         this.arrayConstraintValidator = new ArrayConstraintValidator(failedConstraints);
     }
 
-    public abstract void validate(Object value, AnnotatableType type);
+    public abstract void validate(Object value, AnnotatableType type, String path);
 
     @SuppressWarnings("unchecked")
-    public void validateAnnotations(BMap<BString, Object> annotations, Object fieldValue) {
+    public void validateAnnotations(BMap<BString, Object> annotations, Object fieldValue, String path) {
         for (Map.Entry<BString, Object> annotationRecord : annotations.entrySet()) {
             String annotationTag = annotationRecord.getKey().getValue().
                     substring(Constants.PREFIX_ANNOTATION_RECORD.length());
             BMap<BString, Object> constraints = (BMap<BString, Object>) annotationRecord.getValue();
-            validateAnnotationTags(annotationTag, constraints, fieldValue);
+            validateAnnotationTags(annotationTag, constraints, fieldValue, path);
         }
     }
 
-    private void validateAnnotationTags(String annotationTag, BMap<BString, Object> constraints, Object fieldValue) {
+    private void validateAnnotationTags(String annotationTag, BMap<BString, Object> constraints, Object fieldValue,
+                                        String path) {
         switch (annotationTag) {
             case Constants.ANNOTATION_TAG_INT:
-                this.intConstraintValidator.validate(constraints, (Number) fieldValue);
+                this.intConstraintValidator.validate(constraints, (Number) fieldValue, path);
                 break;
             case Constants.ANNOTATION_TAG_FLOAT:
-                this.floatConstraintValidator.validate(constraints, (Number) fieldValue);
+                this.floatConstraintValidator.validate(constraints, (Number) fieldValue, path);
                 break;
             case Constants.ANNOTATION_TAG_NUMBER:
-                this.numberConstraintValidator.validate(constraints, (Number) fieldValue);
+                this.numberConstraintValidator.validate(constraints, (Number) fieldValue, path);
                 break;
             case Constants.ANNOTATION_TAG_STRING:
-                this.stringConstraintValidator.validate(constraints, (String) fieldValue);
+                this.stringConstraintValidator.validate(constraints, (String) fieldValue, path);
                 break;
             case Constants.ANNOTATION_TAG_ARRAY:
-                this.arrayConstraintValidator.validate(constraints, (Long) fieldValue);
+                this.arrayConstraintValidator.validate(constraints, (Long) fieldValue, path);
                 break;
             default:
                 break;

--- a/native/src/main/java/io/ballerina/stdlib/constraint/annotations/AbstractAnnotations.java
+++ b/native/src/main/java/io/ballerina/stdlib/constraint/annotations/AbstractAnnotations.java
@@ -21,7 +21,6 @@ package io.ballerina.stdlib.constraint.annotations;
 import io.ballerina.runtime.api.types.AnnotatableType;
 import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BString;
-import io.ballerina.stdlib.constraint.Constants;
 import io.ballerina.stdlib.constraint.validators.ArrayConstraintValidator;
 import io.ballerina.stdlib.constraint.validators.FloatConstraintValidator;
 import io.ballerina.stdlib.constraint.validators.IntConstraintValidator;
@@ -30,6 +29,13 @@ import io.ballerina.stdlib.constraint.validators.StringConstraintValidator;
 
 import java.util.List;
 import java.util.Map;
+
+import static io.ballerina.stdlib.constraint.Constants.ANNOTATION_TAG_ARRAY;
+import static io.ballerina.stdlib.constraint.Constants.ANNOTATION_TAG_FLOAT;
+import static io.ballerina.stdlib.constraint.Constants.ANNOTATION_TAG_INT;
+import static io.ballerina.stdlib.constraint.Constants.ANNOTATION_TAG_NUMBER;
+import static io.ballerina.stdlib.constraint.Constants.ANNOTATION_TAG_STRING;
+import static io.ballerina.stdlib.constraint.Constants.PREFIX_ANNOTATION_RECORD;
 
 /**
  * The abstract class to represent the annotation attachment points.
@@ -55,8 +61,7 @@ public abstract class AbstractAnnotations {
     @SuppressWarnings("unchecked")
     public void validateAnnotations(BMap<BString, Object> annotations, Object fieldValue, String path) {
         for (Map.Entry<BString, Object> annotationRecord : annotations.entrySet()) {
-            String annotationTag = annotationRecord.getKey().getValue().
-                    substring(Constants.PREFIX_ANNOTATION_RECORD.length());
+            String annotationTag = annotationRecord.getKey().getValue().substring(PREFIX_ANNOTATION_RECORD.length());
             BMap<BString, Object> constraints = (BMap<BString, Object>) annotationRecord.getValue();
             validateAnnotationTags(annotationTag, constraints, fieldValue, path);
         }
@@ -65,19 +70,19 @@ public abstract class AbstractAnnotations {
     private void validateAnnotationTags(String annotationTag, BMap<BString, Object> constraints, Object fieldValue,
                                         String path) {
         switch (annotationTag) {
-            case Constants.ANNOTATION_TAG_INT:
+            case ANNOTATION_TAG_INT:
                 this.intConstraintValidator.validate(constraints, (Number) fieldValue, path);
                 break;
-            case Constants.ANNOTATION_TAG_FLOAT:
+            case ANNOTATION_TAG_FLOAT:
                 this.floatConstraintValidator.validate(constraints, (Number) fieldValue, path);
                 break;
-            case Constants.ANNOTATION_TAG_NUMBER:
+            case ANNOTATION_TAG_NUMBER:
                 this.numberConstraintValidator.validate(constraints, (Number) fieldValue, path);
                 break;
-            case Constants.ANNOTATION_TAG_STRING:
+            case ANNOTATION_TAG_STRING:
                 this.stringConstraintValidator.validate(constraints, (String) fieldValue, path);
                 break;
-            case Constants.ANNOTATION_TAG_ARRAY:
+            case ANNOTATION_TAG_ARRAY:
                 this.arrayConstraintValidator.validate(constraints, (Long) fieldValue, path);
                 break;
             default:

--- a/native/src/main/java/io/ballerina/stdlib/constraint/annotations/RecordFieldAnnotations.java
+++ b/native/src/main/java/io/ballerina/stdlib/constraint/annotations/RecordFieldAnnotations.java
@@ -28,10 +28,14 @@ import io.ballerina.runtime.api.values.BArray;
 import io.ballerina.runtime.api.values.BDecimal;
 import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BString;
-import io.ballerina.stdlib.constraint.Constants;
 
 import java.util.List;
 import java.util.Map;
+
+import static io.ballerina.stdlib.constraint.Constants.PREFIX_RECORD_FILED;
+import static io.ballerina.stdlib.constraint.Constants.SYMBOL_CLOSE_SQUARE_BRACKET;
+import static io.ballerina.stdlib.constraint.Constants.SYMBOL_DOT;
+import static io.ballerina.stdlib.constraint.Constants.SYMBOL_OPEN_SQUARE_BRACKET;
 
 /**
  * Extern functions for validating constraints on record fields.
@@ -51,13 +55,12 @@ public class RecordFieldAnnotations extends AbstractAnnotations {
         BMap<BString, Object> record = (BMap<BString, Object>) value;
         BMap<BString, Object> recordAnnotations = type.getAnnotations();
         for (Map.Entry<BString, Object> entry : recordAnnotations.entrySet()) {
-            if (entry.getKey().getValue().startsWith(Constants.PREFIX_RECORD_FILED)) {
-                String fieldName = entry.getKey().getValue().substring(Constants.PREFIX_RECORD_FILED.length() + 1);
+            if (entry.getKey().getValue().startsWith(PREFIX_RECORD_FILED)) {
+                String fieldName = entry.getKey().getValue().substring(PREFIX_RECORD_FILED.length() + 1);
                 BMap<BString, Object> recordFieldAnnotations = (BMap<BString, Object>) entry.getValue();
                 Object fieldValue = getFieldValue(record, fieldName);
                 if (fieldValue != null) { // This can be null due to optional fields
-                    super.validateAnnotations(recordFieldAnnotations, fieldValue,
-                            path + Constants.SYMBOL_DOT + fieldName);
+                    super.validateAnnotations(recordFieldAnnotations, fieldValue, path + SYMBOL_DOT + fieldName);
                 }
             }
         }
@@ -84,16 +87,14 @@ public class RecordFieldAnnotations extends AbstractAnnotations {
             if (fieldValue != null) { // This can be null due to optional fields
                 if (fieldType instanceof AnnotatableType) {
                     if (fieldType instanceof RecordType) {
-                        validate(fieldValue, (AnnotatableType) fieldType,
-                                path + Constants.SYMBOL_DOT + fieldName);
+                        validate(fieldValue, (AnnotatableType) fieldType, path + SYMBOL_DOT + fieldName);
                     } else {
                         TypeAnnotations typeAnnotations = new TypeAnnotations(this.failedConstraints);
                         typeAnnotations.validate(fieldValue, (AnnotatableType) fieldType,
-                                path + Constants.SYMBOL_DOT + fieldName);
+                                path + SYMBOL_DOT + fieldName);
                     }
                 } else if (fieldType instanceof ArrayType) {
-                    validateArrayType((ArrayType) fieldType, (BArray) fieldValue,
-                            path + Constants.SYMBOL_DOT + fieldName);
+                    validateArrayType((ArrayType) fieldType, (BArray) fieldValue, path + SYMBOL_DOT + fieldName);
                 }
             }
         }
@@ -107,13 +108,13 @@ public class RecordFieldAnnotations extends AbstractAnnotations {
                 for (int i = 0; i < fieldValue.getLength(); i++) {
                     BMap<BString, Object> map = (BMap<BString, Object>) fieldValue.getRefValue(i);
                     validate(map, (AnnotatableType) elementType,
-                            path + Constants.SYMBOL_OPEN_SQUARE_BRACKET + i + Constants.SYMBOL_CLOSE_SQUARE_BRACKET);
+                            path + SYMBOL_OPEN_SQUARE_BRACKET + i + SYMBOL_CLOSE_SQUARE_BRACKET);
                 }
             } else {
                 TypeAnnotations typeAnnotations = new TypeAnnotations(this.failedConstraints);
                 for (int i = 0; i < fieldValue.getLength(); i++) {
                     typeAnnotations.validate(fieldValue.getRefValue(i), (AnnotatableType) elementType,
-                            path + Constants.SYMBOL_OPEN_SQUARE_BRACKET + i + Constants.SYMBOL_CLOSE_SQUARE_BRACKET);
+                            path + SYMBOL_OPEN_SQUARE_BRACKET + i + SYMBOL_CLOSE_SQUARE_BRACKET);
                 }
             }
         }

--- a/native/src/main/java/io/ballerina/stdlib/constraint/annotations/TypeAnnotations.java
+++ b/native/src/main/java/io/ballerina/stdlib/constraint/annotations/TypeAnnotations.java
@@ -27,9 +27,11 @@ import io.ballerina.runtime.api.values.BArray;
 import io.ballerina.runtime.api.values.BDecimal;
 import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BString;
-import io.ballerina.stdlib.constraint.Constants;
 
 import java.util.List;
+
+import static io.ballerina.stdlib.constraint.Constants.SYMBOL_CLOSE_SQUARE_BRACKET;
+import static io.ballerina.stdlib.constraint.Constants.SYMBOL_OPEN_SQUARE_BRACKET;
 
 /**
  * Extern functions for validating constraints on types.
@@ -87,12 +89,12 @@ public class TypeAnnotations extends AbstractAnnotations {
                 for (int i = 0; i < value.getLength(); i++) {
                     BMap<BString, Object> map = (BMap<BString, Object>) value.getRefValue(i);
                     recordFieldAnnotations.validate(map, (AnnotatableType) elementType,
-                            path + Constants.SYMBOL_OPEN_SQUARE_BRACKET + i + Constants.SYMBOL_CLOSE_SQUARE_BRACKET);
+                            path + SYMBOL_OPEN_SQUARE_BRACKET + i + SYMBOL_CLOSE_SQUARE_BRACKET);
                 }
             } else {
                 for (int i = 0; i < value.getLength(); i++) {
                     validate(value.getRefValue(i), (AnnotatableType) elementType,
-                            path + Constants.SYMBOL_OPEN_SQUARE_BRACKET + i + Constants.SYMBOL_CLOSE_SQUARE_BRACKET);
+                            path + SYMBOL_OPEN_SQUARE_BRACKET + i + SYMBOL_CLOSE_SQUARE_BRACKET);
                 }
             }
         }

--- a/native/src/main/java/io/ballerina/stdlib/constraint/validators/AbstractLengthValidator.java
+++ b/native/src/main/java/io/ballerina/stdlib/constraint/validators/AbstractLengthValidator.java
@@ -37,17 +37,17 @@ public abstract class AbstractLengthValidator {
             switch (constraint.getKey().getValue()) {
                 case Constants.CONSTRAINT_LENGTH:
                     if (!validateLength(fieldValue, constraintValue)) {
-                        failedConstraints.add(path + Constants.SYMBOL_ARROW + Constants.CONSTRAINT_LENGTH);
+                        failedConstraints.add(path + Constants.SYMBOL_SEPERATOR + Constants.CONSTRAINT_LENGTH);
                     }
                     break;
                 case Constants.CONSTRAINT_MIN_LENGTH:
                     if (!validateMinLength(fieldValue, constraintValue)) {
-                        failedConstraints.add(path + Constants.SYMBOL_ARROW + Constants.CONSTRAINT_MIN_LENGTH);
+                        failedConstraints.add(path + Constants.SYMBOL_SEPERATOR + Constants.CONSTRAINT_MIN_LENGTH);
                     }
                     break;
                 case Constants.CONSTRAINT_MAX_LENGTH:
                     if (!validateMaxLength(fieldValue, constraintValue)) {
-                        failedConstraints.add(path + Constants.SYMBOL_ARROW + Constants.CONSTRAINT_MAX_LENGTH);
+                        failedConstraints.add(path + Constants.SYMBOL_SEPERATOR + Constants.CONSTRAINT_MAX_LENGTH);
                     }
                     break;
                 default:

--- a/native/src/main/java/io/ballerina/stdlib/constraint/validators/AbstractLengthValidator.java
+++ b/native/src/main/java/io/ballerina/stdlib/constraint/validators/AbstractLengthValidator.java
@@ -22,31 +22,32 @@ import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BString;
 import io.ballerina.stdlib.constraint.Constants;
 
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * The abstract class to validate the length related constraints.
  */
 public abstract class AbstractLengthValidator {
 
-    public void validate(BMap<BString, Object> constraints, Object fieldValue, Set<String> failedConstraints) {
+    public void validate(BMap<BString, Object> constraints, Object fieldValue, List<String> failedConstraints,
+                         String path) {
         for (Map.Entry<BString, Object> constraint : constraints.entrySet()) {
             long constraintValue = (long) constraint.getValue();
             switch (constraint.getKey().getValue()) {
                 case Constants.CONSTRAINT_LENGTH:
                     if (!validateLength(fieldValue, constraintValue)) {
-                        failedConstraints.add(Constants.CONSTRAINT_LENGTH);
+                        failedConstraints.add(path + Constants.SYMBOL_ARROW + Constants.CONSTRAINT_LENGTH);
                     }
                     break;
                 case Constants.CONSTRAINT_MIN_LENGTH:
                     if (!validateMinLength(fieldValue, constraintValue)) {
-                        failedConstraints.add(Constants.CONSTRAINT_MIN_LENGTH);
+                        failedConstraints.add(path + Constants.SYMBOL_ARROW + Constants.CONSTRAINT_MIN_LENGTH);
                     }
                     break;
                 case Constants.CONSTRAINT_MAX_LENGTH:
                     if (!validateMaxLength(fieldValue, constraintValue)) {
-                        failedConstraints.add(Constants.CONSTRAINT_MAX_LENGTH);
+                        failedConstraints.add(path + Constants.SYMBOL_ARROW + Constants.CONSTRAINT_MAX_LENGTH);
                     }
                     break;
                 default:

--- a/native/src/main/java/io/ballerina/stdlib/constraint/validators/AbstractLengthValidator.java
+++ b/native/src/main/java/io/ballerina/stdlib/constraint/validators/AbstractLengthValidator.java
@@ -20,10 +20,14 @@ package io.ballerina.stdlib.constraint.validators;
 
 import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BString;
-import io.ballerina.stdlib.constraint.Constants;
 
 import java.util.List;
 import java.util.Map;
+
+import static io.ballerina.stdlib.constraint.Constants.CONSTRAINT_LENGTH;
+import static io.ballerina.stdlib.constraint.Constants.CONSTRAINT_MAX_LENGTH;
+import static io.ballerina.stdlib.constraint.Constants.CONSTRAINT_MIN_LENGTH;
+import static io.ballerina.stdlib.constraint.Constants.SYMBOL_SEPARATOR;
 
 /**
  * The abstract class to validate the length related constraints.
@@ -35,19 +39,19 @@ public abstract class AbstractLengthValidator {
         for (Map.Entry<BString, Object> constraint : constraints.entrySet()) {
             long constraintValue = (long) constraint.getValue();
             switch (constraint.getKey().getValue()) {
-                case Constants.CONSTRAINT_LENGTH:
+                case CONSTRAINT_LENGTH:
                     if (!validateLength(fieldValue, constraintValue)) {
-                        failedConstraints.add(path + Constants.SYMBOL_SEPERATOR + Constants.CONSTRAINT_LENGTH);
+                        failedConstraints.add(path + SYMBOL_SEPARATOR + CONSTRAINT_LENGTH);
                     }
                     break;
-                case Constants.CONSTRAINT_MIN_LENGTH:
+                case CONSTRAINT_MIN_LENGTH:
                     if (!validateMinLength(fieldValue, constraintValue)) {
-                        failedConstraints.add(path + Constants.SYMBOL_SEPERATOR + Constants.CONSTRAINT_MIN_LENGTH);
+                        failedConstraints.add(path + SYMBOL_SEPARATOR + CONSTRAINT_MIN_LENGTH);
                     }
                     break;
-                case Constants.CONSTRAINT_MAX_LENGTH:
+                case CONSTRAINT_MAX_LENGTH:
                     if (!validateMaxLength(fieldValue, constraintValue)) {
-                        failedConstraints.add(path + Constants.SYMBOL_SEPERATOR + Constants.CONSTRAINT_MAX_LENGTH);
+                        failedConstraints.add(path + SYMBOL_SEPARATOR + CONSTRAINT_MAX_LENGTH);
                     }
                     break;
                 default:

--- a/native/src/main/java/io/ballerina/stdlib/constraint/validators/AbstractValueValidator.java
+++ b/native/src/main/java/io/ballerina/stdlib/constraint/validators/AbstractValueValidator.java
@@ -34,22 +34,22 @@ public abstract class AbstractValueValidator {
         switch (constraint.getKey().getValue()) {
             case Constants.CONSTRAINT_MIN_VALUE:
                 if (!validateMinValue(fieldValue, constraintValue)) {
-                    failedConstraints.add(path + Constants.SYMBOL_ARROW + Constants.CONSTRAINT_MIN_VALUE);
+                    failedConstraints.add(path + Constants.SYMBOL_SEPERATOR + Constants.CONSTRAINT_MIN_VALUE);
                 }
                 break;
             case Constants.CONSTRAINT_MAX_VALUE:
                 if (!validateMaxValue(fieldValue, constraintValue)) {
-                    failedConstraints.add(path + Constants.SYMBOL_ARROW + Constants.CONSTRAINT_MAX_VALUE);
+                    failedConstraints.add(path + Constants.SYMBOL_SEPERATOR + Constants.CONSTRAINT_MAX_VALUE);
                 }
                 break;
             case Constants.CONSTRAINT_MIN_VALUE_EXCLUSIVE:
                 if (!validateMinValueExclusive(fieldValue, constraintValue)) {
-                    failedConstraints.add(path + Constants.SYMBOL_ARROW + Constants.CONSTRAINT_MIN_VALUE_EXCLUSIVE);
+                    failedConstraints.add(path + Constants.SYMBOL_SEPERATOR + Constants.CONSTRAINT_MIN_VALUE_EXCLUSIVE);
                 }
                 break;
             case Constants.CONSTRAINT_MAX_VALUE_EXCLUSIVE:
                 if (!validateMaxValueExclusive(fieldValue, constraintValue)) {
-                    failedConstraints.add(path + Constants.SYMBOL_ARROW + Constants.CONSTRAINT_MAX_VALUE_EXCLUSIVE);
+                    failedConstraints.add(path + Constants.SYMBOL_SEPERATOR + Constants.CONSTRAINT_MAX_VALUE_EXCLUSIVE);
                 }
                 break;
             default:

--- a/native/src/main/java/io/ballerina/stdlib/constraint/validators/AbstractValueValidator.java
+++ b/native/src/main/java/io/ballerina/stdlib/constraint/validators/AbstractValueValidator.java
@@ -21,8 +21,8 @@ package io.ballerina.stdlib.constraint.validators;
 import io.ballerina.runtime.api.values.BString;
 import io.ballerina.stdlib.constraint.Constants;
 
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * The abstract class to validate the value related constraints.
@@ -30,26 +30,26 @@ import java.util.Set;
 public abstract class AbstractValueValidator {
 
     public void validate(Map.Entry<BString, Object> constraint, Number fieldValue, Number constraintValue,
-                         Set<String> failedConstraints) {
+                         List<String> failedConstraints, String path) {
         switch (constraint.getKey().getValue()) {
             case Constants.CONSTRAINT_MIN_VALUE:
                 if (!validateMinValue(fieldValue, constraintValue)) {
-                    failedConstraints.add(Constants.CONSTRAINT_MIN_VALUE);
+                    failedConstraints.add(path + Constants.SYMBOL_ARROW + Constants.CONSTRAINT_MIN_VALUE);
                 }
                 break;
             case Constants.CONSTRAINT_MAX_VALUE:
                 if (!validateMaxValue(fieldValue, constraintValue)) {
-                    failedConstraints.add(Constants.CONSTRAINT_MAX_VALUE);
+                    failedConstraints.add(path + Constants.SYMBOL_ARROW + Constants.CONSTRAINT_MAX_VALUE);
                 }
                 break;
             case Constants.CONSTRAINT_MIN_VALUE_EXCLUSIVE:
                 if (!validateMinValueExclusive(fieldValue, constraintValue)) {
-                    failedConstraints.add(Constants.CONSTRAINT_MIN_VALUE_EXCLUSIVE);
+                    failedConstraints.add(path + Constants.SYMBOL_ARROW + Constants.CONSTRAINT_MIN_VALUE_EXCLUSIVE);
                 }
                 break;
             case Constants.CONSTRAINT_MAX_VALUE_EXCLUSIVE:
                 if (!validateMaxValueExclusive(fieldValue, constraintValue)) {
-                    failedConstraints.add(Constants.CONSTRAINT_MAX_VALUE_EXCLUSIVE);
+                    failedConstraints.add(path + Constants.SYMBOL_ARROW + Constants.CONSTRAINT_MAX_VALUE_EXCLUSIVE);
                 }
                 break;
             default:

--- a/native/src/main/java/io/ballerina/stdlib/constraint/validators/AbstractValueValidator.java
+++ b/native/src/main/java/io/ballerina/stdlib/constraint/validators/AbstractValueValidator.java
@@ -19,10 +19,15 @@
 package io.ballerina.stdlib.constraint.validators;
 
 import io.ballerina.runtime.api.values.BString;
-import io.ballerina.stdlib.constraint.Constants;
 
 import java.util.List;
 import java.util.Map;
+
+import static io.ballerina.stdlib.constraint.Constants.CONSTRAINT_MAX_VALUE;
+import static io.ballerina.stdlib.constraint.Constants.CONSTRAINT_MAX_VALUE_EXCLUSIVE;
+import static io.ballerina.stdlib.constraint.Constants.CONSTRAINT_MIN_VALUE;
+import static io.ballerina.stdlib.constraint.Constants.CONSTRAINT_MIN_VALUE_EXCLUSIVE;
+import static io.ballerina.stdlib.constraint.Constants.SYMBOL_SEPARATOR;
 
 /**
  * The abstract class to validate the value related constraints.
@@ -32,24 +37,24 @@ public abstract class AbstractValueValidator {
     public void validate(Map.Entry<BString, Object> constraint, Number fieldValue, Number constraintValue,
                          List<String> failedConstraints, String path) {
         switch (constraint.getKey().getValue()) {
-            case Constants.CONSTRAINT_MIN_VALUE:
+            case CONSTRAINT_MIN_VALUE:
                 if (!validateMinValue(fieldValue, constraintValue)) {
-                    failedConstraints.add(path + Constants.SYMBOL_SEPERATOR + Constants.CONSTRAINT_MIN_VALUE);
+                    failedConstraints.add(path + SYMBOL_SEPARATOR + CONSTRAINT_MIN_VALUE);
                 }
                 break;
-            case Constants.CONSTRAINT_MAX_VALUE:
+            case CONSTRAINT_MAX_VALUE:
                 if (!validateMaxValue(fieldValue, constraintValue)) {
-                    failedConstraints.add(path + Constants.SYMBOL_SEPERATOR + Constants.CONSTRAINT_MAX_VALUE);
+                    failedConstraints.add(path + SYMBOL_SEPARATOR + CONSTRAINT_MAX_VALUE);
                 }
                 break;
-            case Constants.CONSTRAINT_MIN_VALUE_EXCLUSIVE:
+            case CONSTRAINT_MIN_VALUE_EXCLUSIVE:
                 if (!validateMinValueExclusive(fieldValue, constraintValue)) {
-                    failedConstraints.add(path + Constants.SYMBOL_SEPERATOR + Constants.CONSTRAINT_MIN_VALUE_EXCLUSIVE);
+                    failedConstraints.add(path + SYMBOL_SEPARATOR + CONSTRAINT_MIN_VALUE_EXCLUSIVE);
                 }
                 break;
-            case Constants.CONSTRAINT_MAX_VALUE_EXCLUSIVE:
+            case CONSTRAINT_MAX_VALUE_EXCLUSIVE:
                 if (!validateMaxValueExclusive(fieldValue, constraintValue)) {
-                    failedConstraints.add(path + Constants.SYMBOL_SEPERATOR + Constants.CONSTRAINT_MAX_VALUE_EXCLUSIVE);
+                    failedConstraints.add(path + SYMBOL_SEPARATOR + CONSTRAINT_MAX_VALUE_EXCLUSIVE);
                 }
                 break;
             default:

--- a/native/src/main/java/io/ballerina/stdlib/constraint/validators/ArrayConstraintValidator.java
+++ b/native/src/main/java/io/ballerina/stdlib/constraint/validators/ArrayConstraintValidator.java
@@ -21,21 +21,21 @@ package io.ballerina.stdlib.constraint.validators;
 import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BString;
 
-import java.util.Set;
+import java.util.List;
 
 /**
  * Extern functions for validating array constraints `@constraint:Array` of Ballerina.
  */
 public class ArrayConstraintValidator extends AbstractLengthValidator {
 
-    private final Set<String> failedConstraints;
+    private final List<String> failedConstraints;
 
-    public ArrayConstraintValidator(Set<String> failedConstraints) {
+    public ArrayConstraintValidator(List<String> failedConstraints) {
         this.failedConstraints = failedConstraints;
     }
 
-    public void validate(BMap<BString, Object> constraints, Long fieldValue) {
-        super.validate(constraints, fieldValue, failedConstraints);
+    public void validate(BMap<BString, Object> constraints, Long fieldValue, String path) {
+        super.validate(constraints, fieldValue, failedConstraints, path);
     }
 
     @Override

--- a/native/src/main/java/io/ballerina/stdlib/constraint/validators/FloatConstraintValidator.java
+++ b/native/src/main/java/io/ballerina/stdlib/constraint/validators/FloatConstraintValidator.java
@@ -21,24 +21,24 @@ package io.ballerina.stdlib.constraint.validators;
 import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BString;
 
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * Extern functions for validating float constraints `@constraint:Float` of Ballerina.
  */
 public class FloatConstraintValidator extends AbstractValueValidator {
 
-    private final Set<String> failedConstraints;
+    private final List<String> failedConstraints;
 
-    public FloatConstraintValidator(Set<String> failedConstraints) {
+    public FloatConstraintValidator(List<String> failedConstraints) {
         this.failedConstraints = failedConstraints;
     }
 
-    public void validate(BMap<BString, Object> constraints, Number fieldValue) {
+    public void validate(BMap<BString, Object> constraints, Number fieldValue, String path) {
         for (Map.Entry<BString, Object> constraint : constraints.entrySet()) {
             Double constraintValue = (Double) constraint.getValue();
-            super.validate(constraint, fieldValue, constraintValue, failedConstraints);
+            super.validate(constraint, fieldValue, constraintValue, failedConstraints, path);
         }
     }
 

--- a/native/src/main/java/io/ballerina/stdlib/constraint/validators/IntConstraintValidator.java
+++ b/native/src/main/java/io/ballerina/stdlib/constraint/validators/IntConstraintValidator.java
@@ -21,24 +21,24 @@ package io.ballerina.stdlib.constraint.validators;
 import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BString;
 
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * Extern functions for validating int constraints `@constraint:Int` of Ballerina.
  */
 public class IntConstraintValidator extends AbstractValueValidator {
 
-    private final Set<String> failedConstraints;
+    private final List<String> failedConstraints;
 
-    public IntConstraintValidator(Set<String> failedConstraints) {
+    public IntConstraintValidator(List<String> failedConstraints) {
         this.failedConstraints = failedConstraints;
     }
 
-    public void validate(BMap<BString, Object> constraints, Number fieldValue) {
+    public void validate(BMap<BString, Object> constraints, Number fieldValue, String path) {
         for (Map.Entry<BString, Object> constraint : constraints.entrySet()) {
             Long constraintValue = (Long) constraint.getValue();
-            super.validate(constraint, fieldValue, constraintValue, failedConstraints);
+            super.validate(constraint, fieldValue, constraintValue, failedConstraints, path);
         }
     }
 

--- a/native/src/main/java/io/ballerina/stdlib/constraint/validators/NumberConstraintValidator.java
+++ b/native/src/main/java/io/ballerina/stdlib/constraint/validators/NumberConstraintValidator.java
@@ -23,24 +23,24 @@ import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BString;
 
 import java.math.BigDecimal;
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * Extern functions for validating number constraints `@constraint:Number` of Ballerina.
  */
 public class NumberConstraintValidator extends AbstractValueValidator {
 
-    private final Set<String> failedConstraints;
+    private final List<String> failedConstraints;
 
-    public NumberConstraintValidator(Set<String> failedConstraints) {
+    public NumberConstraintValidator(List<String> failedConstraints) {
         this.failedConstraints = failedConstraints;
     }
 
-    public void validate(BMap<BString, Object> constraints, Number fieldValue) {
+    public void validate(BMap<BString, Object> constraints, Number fieldValue, String path) {
         for (Map.Entry<BString, Object> constraint : constraints.entrySet()) {
             BigDecimal constraintValue = ((BDecimal) constraint.getValue()).value();
-            super.validate(constraint, fieldValue, constraintValue, failedConstraints);
+            super.validate(constraint, fieldValue, constraintValue, failedConstraints, path);
         }
     }
 

--- a/native/src/main/java/io/ballerina/stdlib/constraint/validators/StringConstraintValidator.java
+++ b/native/src/main/java/io/ballerina/stdlib/constraint/validators/StringConstraintValidator.java
@@ -21,21 +21,21 @@ package io.ballerina.stdlib.constraint.validators;
 import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BString;
 
-import java.util.Set;
+import java.util.List;
 
 /**
  * Extern functions for validating string constraints `@constraint:String` of Ballerina.
  */
 public class StringConstraintValidator extends AbstractLengthValidator {
 
-    private final Set<String> failedConstraints;
+    private final List<String> failedConstraints;
 
-    public StringConstraintValidator(Set<String> failedConstraints) {
+    public StringConstraintValidator(List<String> failedConstraints) {
         this.failedConstraints = failedConstraints;
     }
 
-    public void validate(BMap<BString, Object> constraints, String fieldValue) {
-        super.validate(constraints, fieldValue, failedConstraints);
+    public void validate(BMap<BString, Object> constraints, String fieldValue, String path) {
+        super.validate(constraints, fieldValue, failedConstraints, path);
     }
 
     @Override


### PR DESCRIPTION
## Purpose
This PR improves the error message as JsonPath expression. Now, the error message points to the exact location of the JSON where the constrained value is getting failed.

Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/3143

## Examples
`"Validation failed for '$.bar.baz:minLength','$.bar.baz[0].age:maxValue' constraint(s)."`

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [ ] ~Updated the spec~
