### PR TITLE
Return runtime error for invalid length constraint values

### DIFF
--- a/ballerina/tests/advanced_constraint_test.bal
+++ b/ballerina/tests/advanced_constraint_test.bal
@@ -507,6 +507,66 @@ isolated function testInvalidTypeDescForType() {
     }
 }
 
+// Testing annotation validations by passing invalid length constraint values
+
+int a = -5;
+int b = 0;
+
+@String {
+    length: a
+}
+type StringA string;
+
+@test:Config {}
+function testInvalidLengthConstraintOnStringType() {
+    StringA stringA = "s3cr3t";
+    StringA|error validation = validate(stringA);
+    if validation is error {
+        test:assertEquals(validation.message(), "invalid value found for $:length constraint. Length constraints should be positive");
+    } else {
+        test:assertFail("Expected error not found.");
+    }
+}
+
+@String {
+    maxLength: b
+}
+type StringB string;
+
+type RecordB record {
+    StringB stringB;
+};
+
+@test:Config {}
+function testInvalidLengthConstraintOnStringTypeAsRecordField() {
+    RecordB recordB = {stringB: "s3cr3t"};
+    RecordB|error validation = validate(recordB);
+    if validation is error {
+        test:assertEquals(validation.message(), "invalid value found for $.stringB:maxLength constraint. Length constraints should be positive");
+    } else {
+        test:assertFail("Expected error not found.");
+    }
+}
+
+type RecordA record {
+    @Array {
+        minLength: a
+    }
+    string[] arrayA;
+};
+
+@test:Config {}
+function testInvalidLengthConstraintOnArrayRecordField() {
+    RecordA recordA = {arrayA: ["s3cr3t"]};
+    RecordA|error validation = validate(recordA);
+    if validation is error {
+        test:assertEquals(validation.message(), "invalid value found for $.arrayA:minLength constraint. Length constraints should be positive");
+    } else {
+        test:assertFail("Expected error not found.");
+    }
+}
+
+
 // Testing annotation validations with union type desc
 
 type Union1 record {|

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+- [Fix compiler plugin failure when value is provided through a variable](https://github.com/ballerina-platform/ballerina-standard-library/issues/3580)
+
 ### Changed
 - [API docs updated](https://github.com/ballerina-platform/ballerina-standard-library/issues/3463)
 

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_1/sample.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_1/sample.bal
@@ -74,3 +74,19 @@ type AccountInterest decimal;
     maxLength: 10
 }
 type AccountLast10Transactions float[];
+
+int a = 5;
+
+function getA() returns int {
+    return a;
+}
+
+@constraint:String {
+     length: a
+}
+type StringA string;
+
+@constraint:Int {
+    minValue: getA()
+}
+type IntA int;

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/constraint/compiler/ConstraintCompilerPluginUtils.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/constraint/compiler/ConstraintCompilerPluginUtils.java
@@ -19,6 +19,7 @@
 package io.ballerina.stdlib.constraint.compiler;
 
 import io.ballerina.compiler.syntax.tree.AnnotationNode;
+import io.ballerina.compiler.syntax.tree.BasicLiteralNode;
 import io.ballerina.compiler.syntax.tree.ExpressionNode;
 import io.ballerina.compiler.syntax.tree.MappingConstructorExpressionNode;
 import io.ballerina.compiler.syntax.tree.MappingFieldNode;
@@ -26,6 +27,7 @@ import io.ballerina.compiler.syntax.tree.NodeList;
 import io.ballerina.compiler.syntax.tree.NodeLocation;
 import io.ballerina.compiler.syntax.tree.SeparatedNodeList;
 import io.ballerina.compiler.syntax.tree.SpecificFieldNode;
+import io.ballerina.compiler.syntax.tree.UnaryExpressionNode;
 import io.ballerina.compiler.syntax.tree.UnionTypeDescriptorNode;
 import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
 import io.ballerina.tools.diagnostics.DiagnosticFactory;
@@ -118,7 +120,8 @@ public class ConstraintCompilerPluginUtils {
             for (MappingFieldNode constraint : constraints) {
                 SpecificFieldNode node = (SpecificFieldNode) constraint;
                 Optional<ExpressionNode> valueExpr = node.valueExpr();
-                if (valueExpr.isPresent()) {
+                if (valueExpr.isPresent() && (valueExpr.get() instanceof BasicLiteralNode ||
+                                                valueExpr.get() instanceof UnaryExpressionNode)) {
                     String constraintValue = valueExpr.get().toString().trim()
                             .replaceAll(SYMBOL_NEW_LINE, "")
                             .replaceAll(SYMBOL_DECIMAL, "");

--- a/native/src/main/java/io/ballerina/stdlib/constraint/Constraints.java
+++ b/native/src/main/java/io/ballerina/stdlib/constraint/Constraints.java
@@ -58,6 +58,8 @@ public class Constraints {
                 return ErrorUtils.buildValidationError(failedConstraints);
             }
             return value;
+        } catch (InternalValidationException e) {
+            return ErrorUtils.createError(e.getMessage());
         } catch (RuntimeException e) {
             return ErrorUtils.buildUnexpectedError();
         }

--- a/native/src/main/java/io/ballerina/stdlib/constraint/ErrorUtils.java
+++ b/native/src/main/java/io/ballerina/stdlib/constraint/ErrorUtils.java
@@ -53,7 +53,7 @@ public class ErrorUtils {
         return createError(errorMsg.toString());
     }
 
-    private static BError createError(String errMessage) {
+    static BError createError(String errMessage) {
         return ErrorCreator.createError(ModuleUtils.getModule(), CONSTRAINT_ERROR,
                 StringUtils.fromString(errMessage), null, null);
     }

--- a/native/src/main/java/io/ballerina/stdlib/constraint/InternalValidationException.java
+++ b/native/src/main/java/io/ballerina/stdlib/constraint/InternalValidationException.java
@@ -1,0 +1,11 @@
+package io.ballerina.stdlib.constraint;
+
+/**
+ * Exceptions that could occur in Constraint native level.
+ */
+public class InternalValidationException extends RuntimeException {
+
+    public InternalValidationException(String message) {
+        super(message);
+    }
+}

--- a/native/src/main/java/io/ballerina/stdlib/constraint/validators/AbstractLengthValidator.java
+++ b/native/src/main/java/io/ballerina/stdlib/constraint/validators/AbstractLengthValidator.java
@@ -20,6 +20,7 @@ package io.ballerina.stdlib.constraint.validators;
 
 import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BString;
+import io.ballerina.stdlib.constraint.InternalValidationException;
 
 import java.util.List;
 import java.util.Map;
@@ -38,7 +39,9 @@ public abstract class AbstractLengthValidator {
                          String path) {
         for (Map.Entry<BString, Object> constraint : constraints.entrySet()) {
             long constraintValue = (long) constraint.getValue();
-            switch (constraint.getKey().getValue()) {
+            String constraintFiled = constraint.getKey().getValue();
+            checkLengthConstraintValue(constraintFiled, constraintValue, path);
+            switch (constraintFiled) {
                 case CONSTRAINT_LENGTH:
                     if (!validateLength(fieldValue, constraintValue)) {
                         failedConstraints.add(path + SYMBOL_SEPARATOR + CONSTRAINT_LENGTH);
@@ -57,6 +60,14 @@ public abstract class AbstractLengthValidator {
                 default:
                     break;
             }
+        }
+    }
+
+    static void checkLengthConstraintValue(String constraintField, long constraintValue, String path) {
+        if (constraintValue <= 0) {
+            throw new InternalValidationException("invalid value found for " + path + SYMBOL_SEPARATOR +
+                                                  constraintField + " constraint. Length constraints should be " +
+                                                  "positive");
         }
     }
 

--- a/native/src/main/java/io/ballerina/stdlib/constraint/validators/AbstractLengthValidator.java
+++ b/native/src/main/java/io/ballerina/stdlib/constraint/validators/AbstractLengthValidator.java
@@ -39,9 +39,9 @@ public abstract class AbstractLengthValidator {
                          String path) {
         for (Map.Entry<BString, Object> constraint : constraints.entrySet()) {
             long constraintValue = (long) constraint.getValue();
-            String constraintFiled = constraint.getKey().getValue();
-            checkLengthConstraintValue(constraintFiled, constraintValue, path);
-            switch (constraintFiled) {
+            String constraintField = constraint.getKey().getValue();
+            checkLengthConstraintValue(constraintField, constraintValue, path);
+            switch (constraintField) {
                 case CONSTRAINT_LENGTH:
                     if (!validateLength(fieldValue, constraintValue)) {
                         failedConstraints.add(path + SYMBOL_SEPARATOR + CONSTRAINT_LENGTH);


### PR DESCRIPTION
## Purpose

> $Subject

> Also Fixes : [`Constraint compiler plugin fails when value is provided through a variable #3580`](https://github.com/ballerina-platform/ballerina-standard-library/issues/3580)

## Examples

```ballerina
import ballerina/constraint;
import ballerina/log;

int a = -5;

@constraint:String {
    length: a
}
type StringA string;

public function main() {
    StringA stringA = "s3cr3t";
    StringA|error validation = constraint:validate(stringA);
    if validation is error {
        log:printError("error occurred while validating stringA", validation);
    } 
}
```

```console
$ bal run

Compiling source
        user/pattern_constraint_tests:0.1.0

Running executable

time = 2022-11-03T12:25:49.328+05:30 level = ERROR module = user/pattern_constraint_tests 
message = "error occurred while validating string A" 
error = "invalid value found for $:length constraint. Length constraints should be positive"
```

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [ ] <s>Updated the spec</s>
- [x] Checked native-image compatibility
