### PR TITLE
Add constraint support for `readonly` types

### DIFF
--- a/ballerina/tests/constraint_on_readonly_type_test.bal
+++ b/ballerina/tests/constraint_on_readonly_type_test.bal
@@ -1,0 +1,270 @@
+import ballerina/test;
+
+type Album record {|
+    string title;
+    string artist;
+|};
+
+type ReadOnlyAlbum readonly & Album;
+
+type ReadOnlyAlbumWithoutConstraints readonly & record {|
+    string title;
+    string artist;
+|};
+
+@test:Config {}
+function testReadOnlyAlbumWithoutConstraints() {
+    Album album = {title: "Blue Train", artist: "John Coltrane"};
+    ReadOnlyAlbum|error validation1 = validate(album);
+    if validation1 is error {
+        test:assertFail("Unexpected error found.");
+    }
+
+    ReadOnlyAlbumWithoutConstraints|error validation2 = validate(album);
+    if validation2 is error {
+        test:assertFail("Unexpected error found.");
+    }
+}
+
+type AlbumWithConstraint record {|
+    @String {
+        maxLength: 5,
+        minLength: 1
+    }
+    string title;
+    string artist;
+|};
+
+type ReadOnlyConstrainedAlbum readonly & AlbumWithConstraint;
+
+type ReadOnlyAlbumWithConstraints readonly & record {|
+    @String {
+        maxLength: 5,
+        minLength: 1
+    }
+    string title;
+    string artist;
+|};
+
+@test:Config {}
+function testReadOnlyAlbumWithConstraintsSuccess() {
+    Album album = {title: "Jeru", artist: "Gerry Mulligan"};
+    ReadOnlyConstrainedAlbum|error validation1 = validate(album);
+    if validation1 is error {
+        test:assertFail("Unexpected error found.");
+    }
+
+    ReadOnlyAlbumWithConstraints|error validation2 = validate(album);
+    if validation2 is error {
+        test:assertFail("Unexpected error found.");
+    }
+}
+
+@test:Config {}
+function testReadOnlyAlbumWithConstraintsFailure() {
+    Album album = {title: "Blue Train", artist: "John Coltrane"};
+    ReadOnlyConstrainedAlbum|error validation1 = validate(album);
+    if validation1 is error {
+        test:assertEquals(validation1.message(), "Validation failed for '$.title:maxLength' constraint(s).");
+    } else {
+        test:assertFail("Expected error not found.");
+    }
+
+    ReadOnlyAlbumWithConstraints|error validation2 = validate(album);
+    if validation2 is error {
+        test:assertEquals(validation2.message(), "Validation failed for '$.title:maxLength' constraint(s).");
+    } else {
+        test:assertFail("Expected error not found.");
+    }
+}
+
+type AlbumWithReadOnlyConstraints record {|
+    @String {
+        maxLength: 5,
+        minLength: 1
+    }
+    readonly string title;
+    string artist;
+|};
+
+@test:Config {}
+function testAlbumWithReadOnlyConstraintsSuccess() {
+    Album album = {title: "Jeru", artist: "Gerry Mulligan"};
+    AlbumWithReadOnlyConstraints|error validation = validate(album);
+    if validation is error {
+        test:assertFail("Unexpected error found.");
+    }
+}
+
+@test:Config {}
+function testAlbumWithReadOnlyConstraintsFailure() {
+    Album album = {title: "Blue Train", artist: "John Coltrane"};
+    AlbumWithReadOnlyConstraints|error validation = validate(album);
+    if validation is error {
+        test:assertEquals(validation.message(), "Validation failed for '$.title:maxLength' constraint(s).");
+    } else {
+        test:assertFail("Expected error not found.");
+    }
+}
+
+@String {
+    maxLength: 5,
+    minLength: 1
+}
+type AlbumTitle string;
+
+type ReadOnlyAlbumWithConstraintType readonly & record {|
+    AlbumTitle title;
+    string artist;
+|};
+
+@test:Config {}
+function testReadOnlyAlbumWithConstraintTypeSuccess() {
+    Album album = {title: "Jeru", artist: "Gerry Mulligan"};
+    ReadOnlyAlbumWithConstraintType|error validation = validate(album);
+    if validation is error {
+        test:assertFail("Unexpected error found.");
+    }
+}
+
+@test:Config {}
+function testReadOnlyAlbumWithConstraintTypeFailure() {
+    Album album = {title: "Blue Train", artist: "John Coltrane"};
+    ReadOnlyAlbumWithConstraintType|error validation = validate(album);
+    if validation is error {
+        test:assertEquals(validation.message(), "Validation failed for '$.title:maxLength' constraint(s).");
+    } else {
+        test:assertFail("Expected error not found.");
+    }
+}
+
+@String {
+    maxLength: 5,
+    minLength: 1
+}
+type ReadOnlyAlbumTitle readonly & string;
+
+type AlbumWithReadOnlyConstraintType record {|
+    ReadOnlyAlbumTitle title;
+    string artist;
+|};
+
+@test:Config {}
+function testAlbumWithReadOnlyConstraintTypeSuccess() {
+    Album album = {title: "Jeru", artist: "Gerry Mulligan"};
+    AlbumWithReadOnlyConstraintType|error validation = validate(album);
+    if validation is error {
+        test:assertFail("Unexpected error found.");
+    }
+}
+
+@test:Config {}
+function testAlbumWithReadOnlyConstraintTypeFailure() {
+    Album album = {title: "Blue Train", artist: "John Coltrane"};
+    AlbumWithReadOnlyConstraintType|error validation = validate(album);
+    if validation is error {
+        test:assertEquals(validation.message(), "Validation failed for '$.title:maxLength' constraint(s).");
+    } else {
+        test:assertFail("Expected error not found.");
+    }
+}
+
+@Int {
+    minValue: 0,
+    maxValue: 5
+}
+type Rating int;
+
+type Artist record {|
+    string name;
+    Rating rating;
+    ReadOnlyAlbumWithConstraints[] albums;
+|};
+
+@test:Config {}
+function testArtistSuccess() {
+    Artist artist = {
+        name: "Gerry Mulligan",
+        rating: 4,
+        albums: [
+            {title: "Jeru1", artist: "Gerry Mulligan"},
+            {title: "Jeru2", artist: "Gerry Mulligan"}
+        ]
+    };
+    Artist|error validation = validate(artist);
+    if validation is error {
+        test:assertFail("Unexpected error found.");
+    }
+}
+
+@test:Config {}
+function testArtistFailure() {
+    Artist artist = {
+        name: "John Coltrane",
+        rating: 4,
+        albums: [
+            {title: "Train", artist: "John Coltrane"},
+            {title: "Blue Train", artist: "John Coltrane"}
+        ]
+    };
+    Artist|error validation = validate(artist);
+    if validation is error {
+        test:assertEquals(validation.message(), "Validation failed for '$.albums[1].title:maxLength' constraint(s).");
+    } else {
+        test:assertFail("Expected error not found.");
+    }
+}
+
+type ReadOnlyArtist readonly & Artist;
+
+@test:Config {}
+function testReadOnlyArtistSuccess() {
+    Artist artist = {
+        name: "Gerry Mulligan",
+        rating: 4,
+        albums: [
+            {title: "Jeru1", artist: "Gerry Mulligan"},
+            {title: "Jeru2", artist: "Gerry Mulligan"}
+        ]
+    };
+    ReadOnlyArtist|error validation = validate(artist);
+    if validation is error {
+        test:assertFail("Unexpected error found.");
+    }
+}
+
+@test:Config {}
+function testReadOnlyArtistFailure1() {
+    Artist artist = {
+        name: "Gerry Mulligan",
+        rating: 10,
+        albums: [
+            {title: "Jeru1", artist: "Gerry Mulligan"},
+            {title: "Jeru2", artist: "Gerry Mulligan"}
+        ]
+    };
+    ReadOnlyArtist|error validation = validate(artist);
+    if validation is error {
+        test:assertEquals(validation.message(), "Validation failed for '$.rating:maxValue' constraint(s).");
+    } else {
+        test:assertFail("Expected error not found.");
+    }
+}
+
+@test:Config {}
+function testReadOnlyArtistFailure2() {
+    Artist artist = {
+        name: "John Coltrane",
+        rating: 10,
+        albums: [
+            {title: "Train", artist: "John Coltrane"},
+            {title: "Blue Train", artist: "John Coltrane"}
+        ]
+    };
+    ReadOnlyArtist|error validation = validate(artist);
+    if validation is error {
+        test:assertEquals(validation.message(), "Validation failed for '$.albums[1].title:maxLength','$.rating:maxValue' constraint(s).");
+    } else {
+        test:assertFail("Expected error not found.");
+    }
+}

--- a/ballerina/tests/constraint_on_readonly_type_test.bal
+++ b/ballerina/tests/constraint_on_readonly_type_test.bal
@@ -1,3 +1,19 @@
+// Copyright (c) 2023 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 import ballerina/test;
 
 type Album record {|

--- a/ballerina/tests/constraint_on_readonly_type_test.bal
+++ b/ballerina/tests/constraint_on_readonly_type_test.bal
@@ -20,8 +20,20 @@ function testReadOnlyAlbumWithoutConstraints() {
         test:assertFail("Unexpected error found.");
     }
 
-    ReadOnlyAlbumWithoutConstraints|error validation2 = validate(album);
+    readonly & Album|error validation2 = validate(album);
     if validation2 is error {
+        test:assertFail("Unexpected error found.");
+    }
+
+    do {
+        readonly & Album album1 = check album.cloneWithType();
+        album1 = check validate(album1);
+    } on fail error err {
+        test:assertFail("Unexpected error found.");
+    }
+
+    ReadOnlyAlbumWithoutConstraints|error validation3 = validate(album);
+    if validation3 is error {
         test:assertFail("Unexpected error found.");
     }
 }
@@ -54,8 +66,20 @@ function testReadOnlyAlbumWithConstraintsSuccess() {
         test:assertFail("Unexpected error found.");
     }
 
-    ReadOnlyAlbumWithConstraints|error validation2 = validate(album);
+    readonly & AlbumWithConstraint|error validation2 = validate(album);
     if validation2 is error {
+        test:assertFail("Unexpected error found.");
+    }
+
+    do {
+        readonly & AlbumWithConstraint album1 = check album.cloneWithType();
+        album1 = check validate(album1);
+    } on fail {
+        test:assertFail("Unexpected error found.");
+    }
+
+    ReadOnlyAlbumWithConstraints|error validation3 = validate(album);
+    if validation3 is error {
         test:assertFail("Unexpected error found.");
     }
 }
@@ -70,9 +94,24 @@ function testReadOnlyAlbumWithConstraintsFailure() {
         test:assertFail("Expected error not found.");
     }
 
-    ReadOnlyAlbumWithConstraints|error validation2 = validate(album);
+    readonly & AlbumWithConstraint|error validation2 = validate(album);
     if validation2 is error {
         test:assertEquals(validation2.message(), "Validation failed for '$.title:maxLength' constraint(s).");
+    } else {
+        test:assertFail("Expected error not found.");
+    }
+
+    do {
+        readonly & AlbumWithConstraint album1 = check album.cloneWithType();
+        album1 = check validate(album1);
+        test:assertFail("Expected error not found.");
+    } on fail error err {
+        test:assertEquals(err.message(), "Validation failed for '$.title:maxLength' constraint(s).");
+    }
+
+    ReadOnlyAlbumWithConstraints|error validation3 = validate(album);
+    if validation3 is error {
+        test:assertEquals(validation3.message(), "Validation failed for '$.title:maxLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -227,8 +266,20 @@ function testReadOnlyArtistSuccess() {
             {title: "Jeru2", artist: "Gerry Mulligan"}
         ]
     };
-    ReadOnlyArtist|error validation = validate(artist);
-    if validation is error {
+    ReadOnlyArtist|error validation1 = validate(artist);
+    if validation1 is error {
+        test:assertFail("Unexpected error found.");
+    }
+
+    readonly & Artist|error validation2 = validate(artist);
+    if validation2 is error {
+        test:assertFail("Unexpected error found.");
+    }
+
+    do {
+        readonly & Artist artist1 = check artist.cloneWithType();
+        artist1 = check validate(artist1);
+    } on fail {
         test:assertFail("Unexpected error found.");
     }
 }
@@ -243,11 +294,26 @@ function testReadOnlyArtistFailure1() {
             {title: "Jeru2", artist: "Gerry Mulligan"}
         ]
     };
-    ReadOnlyArtist|error validation = validate(artist);
-    if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$.rating:maxValue' constraint(s).");
+    ReadOnlyArtist|error validation1 = validate(artist);
+    if validation1 is error {
+        test:assertEquals(validation1.message(), "Validation failed for '$.rating:maxValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
+    }
+
+    readonly & Artist|error validation2 = validate(artist);
+    if validation2 is error {
+        test:assertEquals(validation2.message(), "Validation failed for '$.rating:maxValue' constraint(s).");
+    } else {
+        test:assertFail("Expected error not found.");
+    }
+
+    do {
+        readonly & Artist artist1 = check artist.cloneWithType();
+        artist1 = check validate(artist1);
+        test:assertFail("Expected error not found.");
+    } on fail error err {
+        test:assertEquals(err.message(), "Validation failed for '$.rating:maxValue' constraint(s).");
     }
 }
 
@@ -261,10 +327,25 @@ function testReadOnlyArtistFailure2() {
             {title: "Blue Train", artist: "John Coltrane"}
         ]
     };
-    ReadOnlyArtist|error validation = validate(artist);
-    if validation is error {
-        test:assertEquals(validation.message(), "Validation failed for '$.albums[1].title:maxLength','$.rating:maxValue' constraint(s).");
+    ReadOnlyArtist|error validation1 = validate(artist);
+    if validation1 is error {
+        test:assertEquals(validation1.message(), "Validation failed for '$.albums[1].title:maxLength','$.rating:maxValue' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
+    }
+
+    readonly & Artist|error validation2 = validate(artist);
+    if validation2 is error {
+        test:assertEquals(validation2.message(), "Validation failed for '$.albums[1].title:maxLength','$.rating:maxValue' constraint(s).");
+    } else {
+        test:assertFail("Expected error not found.");
+    }
+
+    do {
+        readonly & Artist artist1 = check artist.cloneWithType();
+        artist1 = check validate(artist1);
+        test:assertFail("Expected error not found.");
+    } on fail error err {
+        test:assertEquals(err.message(), "Validation failed for '$.albums[1].title:maxLength','$.rating:maxValue' constraint(s).");
     }
 }

--- a/ballerina/tests/example_constraint_test.bal
+++ b/ballerina/tests/example_constraint_test.bal
@@ -1,3 +1,19 @@
+// Copyright (c) 2022 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 import ballerina/test;
 
 // Testing multiple types of annotations in a practical sample value

--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 - [Add `@pattern` constraint on string types](https://github.com/ballerina-platform/ballerina-standard-library/issues/3179)
+- [Add constraint support for readonly types](https://github.com/ballerina-platform/ballerina-standard-library/issues/3742)
 
 ## [1.0.1] - 2022-11-29
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,4 +6,4 @@ slf4jVersion=1.7.30
 testngVersion=7.4.0
 ballerinaGradlePluginVersion=1.0.0
 
-ballerinaLangVersion=2201.4.0-20230103-130200-7894a0e5
+ballerinaLangVersion=2201.4.0-20230118-220300-dea2287c

--- a/native/src/main/java/io/ballerina/stdlib/constraint/annotations/TypeAnnotations.java
+++ b/native/src/main/java/io/ballerina/stdlib/constraint/annotations/TypeAnnotations.java
@@ -73,7 +73,7 @@ public class TypeAnnotations extends AbstractAnnotations {
         if (referredType.isReadOnly() && referredType instanceof IntersectionType) {
             List<Type> constituentTypes = ((IntersectionType) referredType).getConstituentTypes();
             if (constituentTypes.size() == 2) {
-                referredType = constituentTypes.get(0);
+                referredType = TypeUtils.getReferredType(constituentTypes.get(0));
             }
         }
         if (referredType instanceof AnnotatableType) {

--- a/native/src/main/java/io/ballerina/stdlib/constraint/annotations/TypeAnnotations.java
+++ b/native/src/main/java/io/ballerina/stdlib/constraint/annotations/TypeAnnotations.java
@@ -21,6 +21,7 @@ package io.ballerina.stdlib.constraint.annotations;
 import io.ballerina.runtime.api.TypeTags;
 import io.ballerina.runtime.api.types.AnnotatableType;
 import io.ballerina.runtime.api.types.ArrayType;
+import io.ballerina.runtime.api.types.IntersectionType;
 import io.ballerina.runtime.api.types.RecordType;
 import io.ballerina.runtime.api.types.Type;
 import io.ballerina.runtime.api.utils.TypeUtils;
@@ -69,6 +70,12 @@ public class TypeAnnotations extends AbstractAnnotations {
 
     private void validateReferredType(Object value, Type type, String path) {
         Type referredType = TypeUtils.getReferredType(type);
+        if (referredType.isReadOnly() && referredType instanceof IntersectionType) {
+            List<Type> constituentTypes = ((IntersectionType) referredType).getConstituentTypes();
+            if (constituentTypes.size() == 2) {
+                referredType = constituentTypes.get(0);
+            }
+        }
         if (referredType instanceof AnnotatableType) {
             if (referredType instanceof RecordType) {
                 RecordFieldAnnotations recordFieldAnnotations = new RecordFieldAnnotations(this.failedConstraints);


### PR DESCRIPTION
### Purpose
> $Subject

Fixes : https://github.com/ballerina-platform/ballerina-standard-library/issues/3742

## Examples

```ballerina
import ballerina/io;
import ballerina/constraint;

type Album readonly & record {|
    @constraint:String {
        maxLength: 5,
        minLength: 1
    }
    string title;
    string artist;
|};

public function main() returns error? {
    Album album = {title: "Jeru", artist: "Gerry Mulligan"};
    album = check constraint:validate(album);
}
```

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [ ] <s>Updated the spec</s>
- [x] [Checked native-image compatibility](https://github.com/TharmiganK/module-ballerina-constraint/actions/runs/3994053719)
