### PR TITLE
Ensure value type after constraint validation

### DIFF
--- a/ballerina/constraint.bal
+++ b/ballerina/constraint.bal
@@ -94,7 +94,8 @@ public type ArrayConstraints record {|
     int maxLength?;
 |};
 
-# Validates the provided value against the configured annotations.
+# Validates the provided value against the configured annotations. Additionally, if the type of the value is different
+# from the expected return type then the value will be cloned with the contextually expected type before the validation.
 #
 # + value - The `anydata` type value to be constrained
 # + td - The type descriptor of the value to be constrained

--- a/ballerina/constraint_errors.bal
+++ b/ballerina/constraint_errors.bal
@@ -14,5 +14,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
-# Represents the error type of the module.
+# Represents the generic error type of the module.
 public type Error distinct error;
+
+# Represents the errors occurs during constraint validations.
+public type ValidationError distinct Error;
+
+# Represents the errors occurs during the type conversion.
+public type TypeConversionError distinct Error;

--- a/ballerina/tests/advanced_constraint_test.bal
+++ b/ballerina/tests/advanced_constraint_test.bal
@@ -504,7 +504,7 @@ isolated function testInvalidTypeDescForRecord() {
     ValidRecord rec = {value: "Alice"};
     InvalidRecord|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Unexpected error found due to typedesc and value mismatch.");
+        test:assertEquals(validation.message(), "Type conversion failed due to typedesc and value mismatch.");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -525,7 +525,7 @@ isolated function testInvalidTypeDescForType() {
     ValidType typ = "Alice";
     InvalidType|error validation = validate(typ);
     if validation is error {
-        test:assertEquals(validation.message(), "Unexpected error found due to typedesc and value mismatch.");
+        test:assertEquals(validation.message(), "Type conversion failed due to typedesc and value mismatch.");
     } else {
         test:assertFail("Expected error not found.");
     }

--- a/ballerina/tests/array_constraint_on_record_field_test.bal
+++ b/ballerina/tests/array_constraint_on_record_field_test.bal
@@ -22,7 +22,9 @@ type NoArrayConstraintsOnRecordField record {
 
 @test:Config {}
 isolated function testNoArrayConstraintsOnRecordField() {
-    NoArrayConstraintsOnRecordField rec = {value: [(), true, 123, 123.45, 123.45d, "s3cr3t", xml `<book>The Lost World</book>`, {foo: "bar"}, table key('key) [{'key: 1, value: "foo"}]]};
+    // TODO : Add table - `table key('key) [{'key: 1, value: "foo"}]` after the fix of this issue: 
+    // https://github.com/ballerina-platform/ballerina-lang/issues/39383
+    NoArrayConstraintsOnRecordField rec = {value: [(), true, 123, 123.45, 123.45d, "s3cr3t", xml `<book>The Lost World</book>`, {foo: "bar"}]};
     NoArrayConstraintsOnRecordField|error validation = validate(rec);
     if validation is error {
         test:assertFail("Unexpected error found.");
@@ -60,7 +62,9 @@ isolated function testArrayConstraintLengthOnRecordFieldFailure1() {
 
 @test:Config {}
 isolated function testArrayConstraintLengthOnRecordFieldFailure2() {
-    ArrayConstraintLengthOnRecordField rec = {value: [(), true, 123, 123.45, 123.45d, "s3cr3t", xml `<book>The Lost World</book>`, {foo: "bar"}, table key('key) [{'key: 1, value: "foo"}]]};
+    // TODO : Add table - `table key('key) [{'key: 1, value: "foo"}]` after the fix of this issue: 
+    // https://github.com/ballerina-platform/ballerina-lang/issues/39383
+    ArrayConstraintLengthOnRecordField rec = {value: [(), true, 123, 123.45, 123.45d, "s3cr3t", xml `<book>The Lost World</book>`, {foo: "bar"}]};
     ArrayConstraintLengthOnRecordField|error validation = validate(rec);
     if validation is error {
         test:assertEquals(validation.message(), "Validation failed for '$.value:length' constraint(s).");
@@ -87,7 +91,9 @@ isolated function testArrayConstraintMinLengthOnRecordFieldSuccess1() {
 
 @test:Config {}
 isolated function testArrayConstraintMinLengthOnRecordFieldSuccess2() {
-    ArrayConstraintMinLengthOnRecordField rec = {value: [(), true, 123, 123.45, 123.45d, "s3cr3t", xml `<book>The Lost World</book>`, {foo: "bar"}, table key('key) [{'key: 1, value: "foo"}]]};
+    // TODO : Add table - `table key('key) [{'key: 1, value: "foo"}]` after the fix of this issue: 
+    // https://github.com/ballerina-platform/ballerina-lang/issues/39383
+    ArrayConstraintMinLengthOnRecordField rec = {value: [(), true, 123, 123.45, 123.45d, "s3cr3t", xml `<book>The Lost World</book>`, {foo: "bar"}]};
     ArrayConstraintMinLengthOnRecordField|error validation = validate(rec);
     if validation is error {
         test:assertFail("Unexpected error found.");
@@ -132,7 +138,9 @@ isolated function testArrayConstraintMaxLengthOnRecordFieldSuccess2() {
 
 @test:Config {}
 isolated function testArrayConstraintMaxLengthOnRecordFieldFailure() {
-    ArrayConstraintMaxLengthOnRecordField rec = {value: [(), true, 123, 123.45, 123.45d, "s3cr3t", xml `<book>The Lost World</book>`, {foo: "bar"}, table key('key) [{'key: 1, value: "foo"}]]};
+    // TODO : Add table - `table key('key) [{'key: 1, value: "foo"}]` after the fix of this issue: 
+    // https://github.com/ballerina-platform/ballerina-lang/issues/39383
+    ArrayConstraintMaxLengthOnRecordField rec = {value: [(), true, 123, 123.45, 123.45d, "s3cr3t", xml `<book>The Lost World</book>`, {foo: "bar"}]};
     ArrayConstraintMaxLengthOnRecordField|error validation = validate(rec);
     if validation is error {
         test:assertEquals(validation.message(), "Validation failed for '$.value:maxLength' constraint(s).");
@@ -151,7 +159,9 @@ type ArrayConstraintOnRecordField record {
 
 @test:Config {}
 isolated function testArrayConstraintOnRecordFieldSuccess1() {
-    ArrayConstraintOnRecordField rec = {value: [(), true, 123, 123.45, 123.45d, "s3cr3t", xml `<book>The Lost World</book>`, {foo: "bar"}, table key('key) [{'key: 1, value: "foo"}]]};
+    // TODO : Add table - `table key('key) [{'key: 1, value: "foo"}]` after the fix of this issue: 
+    // https://github.com/ballerina-platform/ballerina-lang/issues/39383
+    ArrayConstraintOnRecordField rec = {value: [(), true, 123, 123.45, 123.45d, "s3cr3t", xml `<book>The Lost World</book>`, {foo: "bar"}]};
     ArrayConstraintOnRecordField|error validation = validate(rec);
     if validation is error {
         test:assertFail("Unexpected error found.");

--- a/ballerina/tests/array_constraint_on_type_as_record_field_test.bal
+++ b/ballerina/tests/array_constraint_on_type_as_record_field_test.bal
@@ -22,7 +22,9 @@ type NoArrayConstraintsOnTypeAsRecordField record {
 
 @test:Config {}
 isolated function testNoArrayConstraintsOnTypeAsRecordField() {
-    NoArrayConstraintsOnTypeAsRecordField rec = {value: [(), true, 123, 123.45, 123.45d, "s3cr3t", xml `<book>The Lost World</book>`, {foo: "bar"}, table key('key) [{'key: 1, value: "foo"}]]};
+    // TODO : Add table - `table key('key) [{'key: 1, value: "foo"}]` after the fix of this issue: 
+    // https://github.com/ballerina-platform/ballerina-lang/issues/39383
+    NoArrayConstraintsOnTypeAsRecordField rec = {value: [(), true, 123, 123.45, 123.45d, "s3cr3t", xml `<book>The Lost World</book>`, {foo: "bar"}]};
     NoArrayConstraintsOnTypeAsRecordField|error validation = validate(rec);
     if validation is error {
         test:assertFail("Unexpected error found.");
@@ -57,7 +59,9 @@ isolated function testArrayConstraintLengthOnTypeAsRecordFieldFailure1() {
 
 @test:Config {}
 isolated function testArrayConstraintLengthOnTypeAsRecordFieldFailure2() {
-    ArrayConstraintLengthOnTypeAsRecordField rec = {value: [(), true, 123, 123.45, 123.45d, "s3cr3t", xml `<book>The Lost World</book>`, {foo: "bar"}, table key('key) [{'key: 1, value: "foo"}]]};
+    // TODO : Add table - `table key('key) [{'key: 1, value: "foo"}]` after the fix of this issue: 
+    // https://github.com/ballerina-platform/ballerina-lang/issues/39383
+    ArrayConstraintLengthOnTypeAsRecordField rec = {value: [(), true, 123, 123.45, 123.45d, "s3cr3t", xml `<book>The Lost World</book>`, {foo: "bar"}]};
     ArrayConstraintLengthOnTypeAsRecordField|error validation = validate(rec);
     if validation is error {
         test:assertEquals(validation.message(), "Validation failed for '$.value:length' constraint(s).");
@@ -81,7 +85,9 @@ isolated function testArrayConstraintMinLengthOnTypeAsRecordFieldSuccess1() {
 
 @test:Config {}
 isolated function testArrayConstraintMinLengthOnTypeAsRecordFieldSuccess2() {
-    ArrayConstraintMinLengthOnTypeAsRecordField rec = {value: [(), true, 123, 123.45, 123.45d, "s3cr3t", xml `<book>The Lost World</book>`, {foo: "bar"}, table key('key) [{'key: 1, value: "foo"}]]};
+    // TODO : Add table - `table key('key) [{'key: 1, value: "foo"}]` after the fix of this issue: 
+    // https://github.com/ballerina-platform/ballerina-lang/issues/39383
+    ArrayConstraintMinLengthOnTypeAsRecordField rec = {value: [(), true, 123, 123.45, 123.45d, "s3cr3t", xml `<book>The Lost World</book>`, {foo: "bar"}]};
     ArrayConstraintMinLengthOnTypeAsRecordField|error validation = validate(rec);
     if validation is error {
         test:assertFail("Unexpected error found.");
@@ -123,7 +129,9 @@ isolated function testArrayConstraintMaxLengthOnTypeAsRecordFieldSuccess2() {
 
 @test:Config {}
 isolated function testArrayConstraintMaxLengthOnTypeAsRecordFieldFailure() {
-    ArrayConstraintMaxLengthOnTypeAsRecordField rec = {value: [(), true, 123, 123.45, 123.45d, "s3cr3t", xml `<book>The Lost World</book>`, {foo: "bar"}, table key('key) [{'key: 1, value: "foo"}]]};
+    // TODO : Add table - `table key('key) [{'key: 1, value: "foo"}]` after the fix of this issue: 
+    // https://github.com/ballerina-platform/ballerina-lang/issues/39383
+    ArrayConstraintMaxLengthOnTypeAsRecordField rec = {value: [(), true, 123, 123.45, 123.45d, "s3cr3t", xml `<book>The Lost World</book>`, {foo: "bar"}]};
     ArrayConstraintMaxLengthOnTypeAsRecordField|error validation = validate(rec);
     if validation is error {
         test:assertEquals(validation.message(), "Validation failed for '$.value:maxLength' constraint(s).");
@@ -138,7 +146,9 @@ type ArrayConstraintOnTypeAsRecordField record {
 
 @test:Config {}
 isolated function testArrayConstraintOnTypeAsRecordFieldSuccess1() {
-    ArrayConstraintOnTypeAsRecordField rec = {value: [(), true, 123, 123.45, 123.45d, "s3cr3t", xml `<book>The Lost World</book>`, {foo: "bar"}, table key('key) [{'key: 1, value: "foo"}]]};
+    // TODO : Add table - `table key('key) [{'key: 1, value: "foo"}]` after the fix of this issue: 
+    // https://github.com/ballerina-platform/ballerina-lang/issues/39383
+    ArrayConstraintOnTypeAsRecordField rec = {value: [(), true, 123, 123.45, 123.45d, "s3cr3t", xml `<book>The Lost World</book>`, {foo: "bar"}]};
     ArrayConstraintOnTypeAsRecordField|error validation = validate(rec);
     if validation is error {
         test:assertFail("Unexpected error found.");

--- a/ballerina/tests/array_constraint_on_type_test.bal
+++ b/ballerina/tests/array_constraint_on_type_test.bal
@@ -20,7 +20,9 @@ type NoArrayConstraintsOnType anydata[];
 
 @test:Config {}
 isolated function testNoArrayConstraintsOnType() {
-    NoArrayConstraintsOnType typ = [(), true, 123, 123.45, 123.45d, "s3cr3t", xml `<book>The Lost World</book>`, {foo: "bar"}, table key('key) [{'key: 1, value: "foo"}]];
+    // TODO : Add table - `table key('key) [{'key: 1, value: "foo"}]` after the fix of this issue: 
+    // https://github.com/ballerina-platform/ballerina-lang/issues/39383
+    NoArrayConstraintsOnType typ = [(), true, 123, 123.45, 123.45d, "s3cr3t", xml `<book>The Lost World</book>`, {foo: "bar"}];
     NoArrayConstraintsOnType|error validation = validate(typ);
     if validation is error {
         test:assertFail("Unexpected error found.");
@@ -56,7 +58,9 @@ isolated function testArrayConstraintLengthOnTypeFailure1() {
 
 @test:Config {}
 isolated function testArrayConstraintLengthOnTypeFailure2() {
-    ArrayConstraintLengthOnType typ = [(), true, 123, 123.45, 123.45d, "s3cr3t", xml `<book>The Lost World</book>`, {foo: "bar"}, table key('key) [{'key: 1, value: "foo"}]];
+    // TODO : Add table - `table key('key) [{'key: 1, value: "foo"}]` after the fix of this issue: 
+    // https://github.com/ballerina-platform/ballerina-lang/issues/39383
+    ArrayConstraintLengthOnType typ = [(), true, 123, 123.45, 123.45d, "s3cr3t", xml `<book>The Lost World</book>`, {foo: "bar"}];
     ArrayConstraintLengthOnType|error validation = validate(typ);
     if validation is error {
         test:assertEquals(validation.message(), "Validation failed for '$:length' constraint(s).");
@@ -81,7 +85,9 @@ isolated function testArrayConstraintMinLengthOnTypeSuccess1() {
 
 @test:Config {}
 isolated function testArrayConstraintMinLengthOnTypeSuccess2() {
-    ArrayConstraintMinLengthOnType typ = [(), true, 123, 123.45, 123.45d, "s3cr3t", xml `<book>The Lost World</book>`, {foo: "bar"}, table key('key) [{'key: 1, value: "foo"}]];
+    // TODO : Add table - `table key('key) [{'key: 1, value: "foo"}]` after the fix of this issue: 
+    // https://github.com/ballerina-platform/ballerina-lang/issues/39383
+    ArrayConstraintMinLengthOnType typ = [(), true, 123, 123.45, 123.45d, "s3cr3t", xml `<book>The Lost World</book>`, {foo: "bar"}];
     ArrayConstraintMinLengthOnType|error validation = validate(typ);
     if validation is error {
         test:assertFail("Unexpected error found.");
@@ -124,7 +130,9 @@ isolated function testArrayConstraintMaxLengthOnTypeSuccess2() {
 
 @test:Config {}
 isolated function testArrayConstraintMaxLengthOnTypeFailure() {
-    ArrayConstraintMaxLengthOnType typ = [(), true, 123, 123.45, 123.45d, "s3cr3t", xml `<book>The Lost World</book>`, {foo: "bar"}, table key('key) [{'key: 1, value: "foo"}]];
+    // TODO : Add table - `table key('key) [{'key: 1, value: "foo"}]` after the fix of this issue: 
+    // https://github.com/ballerina-platform/ballerina-lang/issues/39383
+    ArrayConstraintMaxLengthOnType typ = [(), true, 123, 123.45, 123.45d, "s3cr3t", xml `<book>The Lost World</book>`, {foo: "bar"}];
     ArrayConstraintMaxLengthOnType|error validation = validate(typ);
     if validation is error {
         test:assertEquals(validation.message(), "Validation failed for '$:maxLength' constraint(s).");
@@ -141,7 +149,9 @@ type ArrayConstraintOnType anydata[];
 
 @test:Config {}
 isolated function testArrayConstraintOnTypeSuccess1() {
-    ArrayConstraintOnType typ = [(), true, 123, 123.45, 123.45d, "s3cr3t", xml `<book>The Lost World</book>`, {foo: "bar"}, table key('key) [{'key: 1, value: "foo"}]];
+    // TODO : Add table - `table key('key) [{'key: 1, value: "foo"}]` after the fix of this issue: 
+    // https://github.com/ballerina-platform/ballerina-lang/issues/39383
+    ArrayConstraintOnType typ = [(), true, 123, 123.45, 123.45d, "s3cr3t", xml `<book>The Lost World</book>`, {foo: "bar"}];
     ArrayConstraintOnType|error validation = validate(typ);
     if validation is error {
         test:assertFail("Unexpected error found.");

--- a/ballerina/tests/constraint_validation_return_type_test.bal
+++ b/ballerina/tests/constraint_validation_return_type_test.bal
@@ -55,7 +55,7 @@ function testValidationWithCloneWithTypeFailure1() {
     json rec = {"id": 1, "username": "Joy"};
     User|error validation = validate(rec);
     if validation is error {
-        test:assertEquals(validation.message(), "Unexpected error found due to typedesc and value mismatch.");
+        test:assertEquals(validation.message(), "Type conversion failed due to typedesc and value mismatch.");
     } else {
         test:assertFail("Expected error not found.");
     }
@@ -68,7 +68,7 @@ function testValidationWithCloneWithTypeFailure2() {
         User _ = check validate(rec);
         test:assertFail("Expected error not found.");
     } on fail error err {
-        test:assertEquals(err.message(), "Unexpected error found due to typedesc and value mismatch.");
+        test:assertEquals(err.message(), "Type conversion failed due to typedesc and value mismatch.");
     }
 }
 

--- a/ballerina/tests/constraint_validation_return_type_test.bal
+++ b/ballerina/tests/constraint_validation_return_type_test.bal
@@ -1,0 +1,100 @@
+// Copyright (c) 2023 WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/test;
+
+type User record {|
+    int id;
+    @String {
+        minLength: 2
+    }
+    string name;
+|};
+
+@test:Config {}
+function testValidationWithCloneWithTypeSuccess1() {
+    json rec = {"id": 1, "name": "Joy"};
+    User|error validation = validate(rec);
+    if validation is error {
+        test:assertFail("Unexpected error found.");
+    } else {
+        test:assertEquals(validation, rec);
+        test:assertTrue(validation is User);
+        test:assertNotExactEquals(validation, rec);
+    }
+}
+
+@test:Config {}
+function testValidationWithCloneWithTypeSuccess2() {
+    json rec = {"id": 1, "name": "Joy"};
+    do {
+        User validation = check validate(rec);
+        test:assertEquals(validation, rec);
+        test:assertTrue(validation is User);
+        test:assertNotExactEquals(validation, rec);
+    } on fail {
+        test:assertFail("Unexpected error found.");
+    }
+}
+
+@test:Config {}
+function testValidationWithCloneWithTypeFailure1() {
+    json rec = {"id": 1, "username": "Joy"};
+    User|error validation = validate(rec);
+    if validation is error {
+        test:assertEquals(validation.message(), "Unexpected error found due to typedesc and value mismatch.");
+    } else {
+        test:assertFail("Expected error not found.");
+    }
+}
+
+@test:Config {}
+function testValidationWithCloneWithTypeFailure2() {
+    json rec = {"id": 1, "username": "Joy"};
+    do {
+        User _ = check validate(rec);
+        test:assertFail("Expected error not found.");
+    } on fail error err {
+        test:assertEquals(err.message(), "Unexpected error found due to typedesc and value mismatch.");
+    }
+}
+
+@test:Config {}
+function testValidationWithoutCloneSuccess1() {
+    User rec = {"id": 1, "name": "Joy"};
+    User|error validation = validate(rec);
+    if validation is error {
+        test:assertFail("Unexpected error found.");
+    } else {
+        test:assertEquals(validation, rec);
+        test:assertTrue(validation is User);
+        test:assertExactEquals(validation, rec);
+    }
+}
+
+@test:Config {}
+function testValidationWithoutCloneSuccess2() {
+    User rec = {"id": 1, "name": "Joy"};
+    do {
+        User validation = check validate(rec);
+        test:assertEquals(validation, rec);
+        test:assertTrue(validation is User);
+        test:assertExactEquals(validation, rec);
+    } on fail {
+        test:assertFail("Unexpected error found.");
+    }
+}
+

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 - [Fix unexpected errors due to custom annotations](https://github.com/ballerina-platform/ballerina-standard-library/issues/3817)
+- [Ensure value type after constraint validation](https://github.com/ballerina-platform/ballerina-standard-library/issues/3976)
+
 
 ### Added
 - [Add `@pattern` constraint on string types](https://github.com/ballerina-platform/ballerina-standard-library/issues/3179)

--- a/changelog.md
+++ b/changelog.md
@@ -9,7 +9,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Fix unexpected errors due to custom annotations](https://github.com/ballerina-platform/ballerina-standard-library/issues/3817)
 - [Ensure value type after constraint validation](https://github.com/ballerina-platform/ballerina-standard-library/issues/3976)
 
-
 ### Added
 - [Add `@pattern` constraint on string types](https://github.com/ballerina-platform/ballerina-standard-library/issues/3179)
 - [Add constraint support for readonly types](https://github.com/ballerina-platform/ballerina-standard-library/issues/3742)

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -226,9 +226,9 @@ type Names string[];
 ## 3. `validate` function
 
 The Constraint library has a public function : `validate` which should be explicitly called by the developer to 
-validate the constraints. If the validation is successful then this function returns the type descriptor of the 
-value which is validated, else a `constraint:Error` is returned. Additionally, if the type of the value is different
-from the expected return type then the value will be cloned with the contextually expected type before the validation.
+validate the constraints. If the validation is successful then this function returns the validated value, else
+a `constraint:Error` is returned. Additionally, if the type of the value is different from the expected return
+type then the value will be cloned with the contextually expected type before the validation.
 
 The following is the definition of the `validate` function.
 ```ballerina

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -227,7 +227,8 @@ type Names string[];
 
 The Constraint library has a public function : `validate` which should be explicitly called by the developer to 
 validate the constraints. If the validation is successful then this function returns the type descriptor of the 
-value which is validated, else a `constraint:Error` is returned.
+value which is validated, else a `constraint:Error` is returned. Additionally, if the type of the value is different
+from the expected return type then the value will be cloned with the contextually expected type before the validation.
 
 The following is the definition of the `validate` function.
 ```ballerina

--- a/native/build.gradle
+++ b/native/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     implementation group: 'org.ballerinalang', name: 'ballerina-runtime', version: "${ballerinaLangVersion}"
     implementation group: 'org.slf4j', name: 'slf4j-jdk14', version: "${slf4jVersion}"
     implementation group: 'org.ballerinalang', name: 'regexp', version: "${ballerinaLangVersion}"
+    implementation group: 'org.ballerinalang', name: 'value', version: "${ballerinaLangVersion}"
 }
 
 checkstyle {

--- a/native/src/main/java/io/ballerina/stdlib/constraint/Constants.java
+++ b/native/src/main/java/io/ballerina/stdlib/constraint/Constants.java
@@ -49,5 +49,7 @@ public class Constants {
     public static final String CONSTRAINT_MAX_LENGTH = "maxLength";
     public static final String CONSTRAINT_PATTERN = "pattern";
 
-    static final String CONSTRAINT_ERROR = "Error";
+    static final String GENERIC_ERROR = "Error";
+    static final String VALIDATION_ERROR = "ValidationError";
+    static final String TYPE_CONVERSION_ERROR = "TypeConversionError";
 }

--- a/native/src/main/java/io/ballerina/stdlib/constraint/ErrorUtils.java
+++ b/native/src/main/java/io/ballerina/stdlib/constraint/ErrorUtils.java
@@ -25,9 +25,11 @@ import io.ballerina.runtime.api.values.BError;
 import java.util.Collections;
 import java.util.List;
 
-import static io.ballerina.stdlib.constraint.Constants.CONSTRAINT_ERROR;
+import static io.ballerina.stdlib.constraint.Constants.GENERIC_ERROR;
 import static io.ballerina.stdlib.constraint.Constants.SYMBOL_COMMA;
 import static io.ballerina.stdlib.constraint.Constants.SYMBOL_SINGLE_QUOTE;
+import static io.ballerina.stdlib.constraint.Constants.TYPE_CONVERSION_ERROR;
+import static io.ballerina.stdlib.constraint.Constants.VALIDATION_ERROR;
 
 /**
  * Utility functions related to errors.
@@ -35,14 +37,16 @@ import static io.ballerina.stdlib.constraint.Constants.SYMBOL_SINGLE_QUOTE;
 public class ErrorUtils {
 
     private static final String UNEXPECTED_ERROR_MESSAGE = "Unexpected error found due to typedesc and value mismatch.";
+    private static final String TYPE_CONVERSION_ERROR_MESSAGE = "Type conversion failed due to typedesc and value " +
+            "mismatch.";
     private static final String VALIDATION_ERROR_MESSAGE_PREFIX = "Validation failed for ";
     private static final String VALIDATION_ERROR_MESSAGE_SUFFIX = " constraint(s).";
 
     static BError buildUnexpectedError(RuntimeException e) {
         if (e instanceof BError) {
-            return createError(UNEXPECTED_ERROR_MESSAGE, (BError) e);
+            return createError(UNEXPECTED_ERROR_MESSAGE, (BError) e, GENERIC_ERROR);
         }
-        return createError(UNEXPECTED_ERROR_MESSAGE);
+        return createGenericError(UNEXPECTED_ERROR_MESSAGE);
     }
 
     static BError buildValidationError(List<String> failedConstraints) {
@@ -53,16 +57,25 @@ public class ErrorUtils {
         }
         errorMsg.deleteCharAt(errorMsg.length() - 1);
         errorMsg.append(VALIDATION_ERROR_MESSAGE_SUFFIX);
-        return createError(errorMsg.toString());
+        return createError(errorMsg.toString(), VALIDATION_ERROR);
     }
 
-    static BError createError(String errMessage) {
-        return ErrorCreator.createError(ModuleUtils.getModule(), CONSTRAINT_ERROR,
-                StringUtils.fromString(errMessage), null, null);
+    static BError buildTypeConversionError(BError err) {
+        return createError(TYPE_CONVERSION_ERROR_MESSAGE, err, TYPE_CONVERSION_ERROR);
     }
 
-    static BError createError(String errMessage, BError err) {
-        return ErrorCreator.createError(ModuleUtils.getModule(), CONSTRAINT_ERROR,
+    static BError createGenericError(String errMessage) {
+        return ErrorCreator.createError(ModuleUtils.getModule(), GENERIC_ERROR,
+                                        StringUtils.fromString(errMessage), null, null);
+    }
+
+    static BError createError(String errMessage, String errorType) {
+        return ErrorCreator.createError(ModuleUtils.getModule(), errorType,
+                                        StringUtils.fromString(errMessage), null, null);
+    }
+
+    static BError createError(String errMessage, BError err, String errorType) {
+        return ErrorCreator.createError(ModuleUtils.getModule(), errorType,
                                         StringUtils.fromString(errMessage), err, null);
     }
 }

--- a/native/src/main/java/io/ballerina/stdlib/constraint/ErrorUtils.java
+++ b/native/src/main/java/io/ballerina/stdlib/constraint/ErrorUtils.java
@@ -38,7 +38,10 @@ public class ErrorUtils {
     private static final String VALIDATION_ERROR_MESSAGE_PREFIX = "Validation failed for ";
     private static final String VALIDATION_ERROR_MESSAGE_SUFFIX = " constraint(s).";
 
-    static BError buildUnexpectedError() {
+    static BError buildUnexpectedError(RuntimeException e) {
+        if (e instanceof BError) {
+            return createError(UNEXPECTED_ERROR_MESSAGE, (BError) e);
+        }
         return createError(UNEXPECTED_ERROR_MESSAGE);
     }
 
@@ -56,5 +59,10 @@ public class ErrorUtils {
     static BError createError(String errMessage) {
         return ErrorCreator.createError(ModuleUtils.getModule(), CONSTRAINT_ERROR,
                 StringUtils.fromString(errMessage), null, null);
+    }
+
+    static BError createError(String errMessage, BError err) {
+        return ErrorCreator.createError(ModuleUtils.getModule(), CONSTRAINT_ERROR,
+                                        StringUtils.fromString(errMessage), err, null);
     }
 }

--- a/native/src/main/java/module-info.java
+++ b/native/src/main/java/module-info.java
@@ -16,6 +16,7 @@
  */
 
 module io.ballerina.stdlib.constraint {
+    requires io.ballerina.lang.value;
     requires io.ballerina.runtime;
     requires java.naming;
     requires org.slf4j;


### PR DESCRIPTION
## Purpose
> $Subject

Fixes : https://github.com/ballerina-platform/ballerina-standard-library/issues/3976

## Examples

```ballerina
import ballerina/constraint;
import ballerina/io;

type User record {|
    int id;
    @constraint:String {
        minLength: 2
    }
    string name;
|};

public function main() returns error? {
    json j1 = {"id": 1, "name": "Joy"};
    // j1 will be cloned with User type
    User user1 = check constraint:validate(j1);
    io:println(user1 is User); // prints true
    io:println(user1 === j1); // prints false

    User user = {"id": 1, "name": "Joy"};
    // user will not be cloned
    user = check constraint:validate(user);
    io:println(user is User); // prints true

    // user will not be cloned 
    User validation = check constraint:validate(user);
    io:println(validation is User); // prints true
    io:println(validation === user); // prints true

    json j2 = {"id": 1, "username": "Joy"};
    User _ = check constraint:validate(j2); // Returns an error
}
``` 

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [x] Updated the spec
- [x] [Checked native-image compatibility](https://github.com/TharmiganK/module-ballerina-constraint/actions/runs/4042342135)
