### PR TITLE
Fix constraint validation on array members

### DIFF
--- a/ballerina/tests/advanced_constraint_test.bal
+++ b/ballerina/tests/advanced_constraint_test.bal
@@ -661,9 +661,7 @@ isolated function testUnionTypeDescFailure2() {
     }
 }
 
-// TODO: Following test cases are disabled due to https://github.com/ballerina-platform/ballerina-lang/issues/37050
-
-@test:Config {enable: false}
+@test:Config {}
 isolated function testUnionTypeDescFailure3() {
     Union1|Union2|Union3 typ = 5.1;
     Union1|Union2|Union3|error validation = validate(typ);

--- a/ballerina/tests/constraint_on_array_members_test.bal
+++ b/ballerina/tests/constraint_on_array_members_test.bal
@@ -1,0 +1,156 @@
+// Copyright (c) 2023 WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/test;
+
+@String {length: 4}
+type UserId string;
+
+@Array {length: 4}
+type UserIdArray UserId[];
+
+type App1 record {|
+    UserIdArray ids;
+|};
+
+type App2 record {|
+    UserId[] ids;
+|};
+
+@Array {maxLength: 2}
+type Users User[];
+
+@test:Config {}
+function testConstraintsOnArrayBasicMembersSuccess() {
+    UserId[] ids = ["1234", "4356", "9834", "3214"];
+    do {
+        ids = check validate(ids);
+    } on fail {
+        test:assertFail("Unexpected error found.");
+    }
+
+    UserIdArray|error validation = validate(ids);
+    if validation is error {
+        test:assertFail("Unexpected error found.");
+    }
+}
+
+@test:Config {}
+function testConstraintsOnArrayBasicMembersFailure() {
+    UserId[] ids = ["1234", "43", "9834", "3214"];
+    do {
+        ids = check validate(ids);
+        test:assertFail("Unexpected error found.");
+    } on fail error err {
+        test:assertEquals(err.message(), "Validation failed for '$[1]:length' constraint(s).");
+    }
+
+    UserIdArray|error validation1 = validate(ids);
+    if validation1 is error {
+        test:assertEquals(validation1.message(), "Validation failed for '$[1]:length' constraint(s).");
+    } else {
+        test:assertFail("Unexpected error found.");
+    }
+
+    UserIdArray|error validation2 = validate([...ids, "32"]);
+    if validation2 is error {
+        test:assertEquals(validation2.message(), "Validation failed for '$:length','$[1]:length','$[4]:length' constraint(s).");
+    } else {
+        test:assertFail("Unexpected error found.");
+    }
+}
+
+@test:Config {}
+function testConstraintsOnRecordFieldArrayMembersSuccess() {
+    UserId[] ids = ["1234", "4356", "9834", "3214"];
+
+    App1|error validation1 = validate({ids: ids});
+    if validation1 is error {
+        test:assertFail("Unexpected error found.");
+    }
+
+    App2|error validation2 = validate({ids: ids});
+    if validation2 is error {
+        test:assertFail("Unexpected error found.");
+    }
+}
+
+@test:Config {}
+function testConstraintsOnRecordFieldArrayMembersFailure() {
+    UserId[] ids = ["1234", "43", "9834", "3214"];
+
+    App1|error validation1 = validate({ids: ids});
+    if validation1 is error {
+        test:assertEquals(validation1.message(), "Validation failed for '$.ids[1]:length' constraint(s).");
+    } else {
+        test:assertFail("Unexpected error found.");
+    }
+
+    App2|error validation2 = validate({ids: ids});
+    if validation2 is error {
+        test:assertEquals(validation2.message(), "Validation failed for '$.ids[1]:length' constraint(s).");
+    } else {
+        test:assertFail("Unexpected error found.");
+    }
+}
+
+@test:Config {}
+function testConstraintsOnRecordArrayMemberSuccess() {
+    User[] users = [
+        {id: 1, name: "John"},
+        {id: 2, name: "Joyce"}
+    ];
+
+    do {
+        users = check validate(users);
+    } on fail {
+        test:assertFail("Unexpected error found.");
+    }
+
+    Users|error validation = validate(users);
+    if validation is error {
+        test:assertFail("Unexpected error found.");
+    }
+}
+
+@test:Config {}
+function testConstraintsOnRecordArrayMemberFailure() {
+    User[] users = [
+        {id: 1, name: "John"},
+        {id: 2, name: "a"}
+    ];
+
+    do {
+        users = check validate(users);
+        test:assertFail("Unexpected error found.");
+    } on fail error err {
+        test:assertEquals(err.message(), "Validation failed for '$[1].name:minLength' constraint(s).");
+    }
+
+    Users|error validation1 = validate(users);
+    if validation1 is error {
+        test:assertEquals(validation1.message(), "Validation failed for '$[1].name:minLength' constraint(s).");
+    } else {
+        test:assertFail("Unexpected error found.");
+    }
+
+    Users|error validation2 = validate([...users, {id: 3, name: "Joyce"}]);
+    if validation2 is error {
+        test:assertEquals(validation2.message(), "Validation failed for '$:maxLength','$[1].name:minLength' constraint(s).");
+    } else {
+        test:assertFail("Unexpected error found.");
+    }
+}

--- a/ballerina/tests/constraint_on_readonly_type_test.bal
+++ b/ballerina/tests/constraint_on_readonly_type_test.bal
@@ -1,6 +1,6 @@
-// Copyright (c) 2023 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+// Copyright (c) 2023 WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
 //
-// WSO2 Inc. licenses this file to you under the Apache License,
+// WSO2 LLC. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except
 // in compliance with the License.
 // You may obtain a copy of the License at

--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 - [Fix unexpected errors due to custom annotations](https://github.com/ballerina-platform/ballerina-standard-library/issues/3817)
 - [Ensure value type after constraint validation](https://github.com/ballerina-platform/ballerina-standard-library/issues/3976)
+- [Fix constraint validation on array members](https://github.com/ballerina-platform/ballerina-standard-library/issues/3974)
 
 ### Added
 - [Add `@pattern` constraint on string types](https://github.com/ballerina-platform/ballerina-standard-library/issues/3179)

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -3,7 +3,7 @@
 _Owners_: @TharmiganK @shafreenAnfar @chamil321  
 _Reviewers_: @shafreenAnfar @chamil321  
 _Created_: 2022/08/09  
-_Updated_: 2022/08/09   
+_Updated_: 2023/01/31   
 _Edition_: Swan Lake
 
 ## Introduction


### PR DESCRIPTION
## Purpose

> $Subject

Fixes : https://github.com/ballerina-platform/ballerina-standard-library/issues/3974

## Examples

```bal
import ballerina/constraint;

type User record {|
    int id;
    @constraint:String {
        minLength: 2
    }
    string name;
|};

public function main() returns error? {
    User[] users = [
        {id: 1, name: "John"},
        {id: 2, name: "Joe"},
        {id: 3, name: "A"}
    ];
    users = check constraint:validate(users);
    // error: Validation failed for '$[2].name:minLength' constraint(s).
}
```

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [ ] <s>Updated the spec</s>
- [x] [Checked native-image compatibility](https://github.com/TharmiganK/module-ballerina-constraint/actions/runs/4071712625)
