### PR TITLE
[2201.2.x] Fix constraint validation on array members

### DIFF
--- a/ballerina/tests/constraint_on_array_members_test.bal
+++ b/ballerina/tests/constraint_on_array_members_test.bal
@@ -51,23 +51,24 @@ function testConstraintsOnArrayBasicMembersSuccess() {
 @test:Config {}
 function testConstraintsOnArrayBasicMembersFailure() {
     UserId[] ids = ["1234", "43", "9834", "3214"];
-    do {
-        ids = check validate(ids);
-        test:assertFail("Unexpected error found.");
-    } on fail error err {
-        test:assertEquals(err.message(), "Validation failed for '$[1]:length' constraint(s).");
-    }
 
-    UserIdArray|error validation1 = validate(ids);
+    UserId[]|error validation1 = validate(ids);
     if validation1 is error {
         test:assertEquals(validation1.message(), "Validation failed for '$[1]:length' constraint(s).");
     } else {
         test:assertFail("Unexpected error found.");
     }
 
-    UserIdArray|error validation2 = validate([...ids, "32"]);
+    UserIdArray|error validation2 = validate([...ids]);
     if validation2 is error {
-        test:assertEquals(validation2.message(), "Validation failed for '$:length','$[1]:length','$[4]:length' constraint(s).");
+        test:assertEquals(validation2.message(), "Validation failed for '$[1]:length' constraint(s).");
+    } else {
+        test:assertFail("Unexpected error found.");
+    }
+
+    UserIdArray|error validation3 = validate([...ids, "32"]);
+    if validation3 is error {
+        test:assertEquals(validation3.message(), "Validation failed for '$:length','$[1]:length','$[4]:length' constraint(s).");
     } else {
         test:assertFail("Unexpected error found.");
     }
@@ -133,23 +134,23 @@ function testConstraintsOnRecordArrayMemberFailure() {
         {id: 2, name: "a"}
     ];
 
-    do {
-        users = check validate(users);
-        test:assertFail("Unexpected error found.");
-    } on fail error err {
-        test:assertEquals(err.message(), "Validation failed for '$[1].name:minLength' constraint(s).");
-    }
-
-    Users|error validation1 = validate(users);
+    User[]|error validation1 = validate(users);
     if validation1 is error {
         test:assertEquals(validation1.message(), "Validation failed for '$[1].name:minLength' constraint(s).");
     } else {
         test:assertFail("Unexpected error found.");
     }
 
-    Users|error validation2 = validate([...users, {id: 3, name: "Joyce"}]);
+    Users|error validation2 = validate([...users]);
     if validation2 is error {
-        test:assertEquals(validation2.message(), "Validation failed for '$:maxLength','$[1].name:minLength' constraint(s).");
+        test:assertEquals(validation2.message(), "Validation failed for '$[1].name:minLength' constraint(s).");
+    } else {
+        test:assertFail("Unexpected error found.");
+    }
+
+    Users|error validation3 = validate([...users, {id: 3, name: "Joyce"}]);
+    if validation3 is error {
+        test:assertEquals(validation3.message(), "Validation failed for '$:maxLength','$[1].name:minLength' constraint(s).");
     } else {
         test:assertFail("Unexpected error found.");
     }

--- a/ballerina/tests/constraint_on_array_members_test.bal
+++ b/ballerina/tests/constraint_on_array_members_test.bal
@@ -1,0 +1,156 @@
+// Copyright (c) 2023 WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/test;
+
+@String {length: 4}
+type UserId string;
+
+@Array {length: 4}
+type UserIdArray UserId[];
+
+type App1 record {|
+    UserIdArray ids;
+|};
+
+type App2 record {|
+    UserId[] ids;
+|};
+
+@Array {maxLength: 2}
+type Users User[];
+
+@test:Config {}
+function testConstraintsOnArrayBasicMembersSuccess() {
+    UserId[] ids = ["1234", "4356", "9834", "3214"];
+    do {
+        ids = check validate(ids);
+    } on fail {
+        test:assertFail("Unexpected error found.");
+    }
+
+    UserIdArray|error validation = validate(ids);
+    if validation is error {
+        test:assertFail("Unexpected error found.");
+    }
+}
+
+@test:Config {}
+function testConstraintsOnArrayBasicMembersFailure() {
+    UserId[] ids = ["1234", "43", "9834", "3214"];
+    do {
+        ids = check validate(ids);
+        test:assertFail("Unexpected error found.");
+    } on fail error err {
+        test:assertEquals(err.message(), "Validation failed for '$[1]:length' constraint(s).");
+    }
+
+    UserIdArray|error validation1 = validate(ids);
+    if validation1 is error {
+        test:assertEquals(validation1.message(), "Validation failed for '$[1]:length' constraint(s).");
+    } else {
+        test:assertFail("Unexpected error found.");
+    }
+
+    UserIdArray|error validation2 = validate([...ids, "32"]);
+    if validation2 is error {
+        test:assertEquals(validation2.message(), "Validation failed for '$:length','$[1]:length','$[4]:length' constraint(s).");
+    } else {
+        test:assertFail("Unexpected error found.");
+    }
+}
+
+@test:Config {}
+function testConstraintsOnRecordFieldArrayMembersSuccess() {
+    UserId[] ids = ["1234", "4356", "9834", "3214"];
+
+    App1|error validation1 = validate({ids: ids});
+    if validation1 is error {
+        test:assertFail("Unexpected error found.");
+    }
+
+    App2|error validation2 = validate({ids: ids});
+    if validation2 is error {
+        test:assertFail("Unexpected error found.");
+    }
+}
+
+@test:Config {}
+function testConstraintsOnRecordFieldArrayMembersFailure() {
+    UserId[] ids = ["1234", "43", "9834", "3214"];
+
+    App1|error validation1 = validate({ids: ids});
+    if validation1 is error {
+        test:assertEquals(validation1.message(), "Validation failed for '$.ids[1]:length' constraint(s).");
+    } else {
+        test:assertFail("Unexpected error found.");
+    }
+
+    App2|error validation2 = validate({ids: ids});
+    if validation2 is error {
+        test:assertEquals(validation2.message(), "Validation failed for '$.ids[1]:length' constraint(s).");
+    } else {
+        test:assertFail("Unexpected error found.");
+    }
+}
+
+@test:Config {}
+function testConstraintsOnRecordArrayMemberSuccess() {
+    User[] users = [
+        {id: 1, name: "John"},
+        {id: 2, name: "Joyce"}
+    ];
+
+    do {
+        users = check validate(users);
+    } on fail {
+        test:assertFail("Unexpected error found.");
+    }
+
+    Users|error validation = validate(users);
+    if validation is error {
+        test:assertFail("Unexpected error found.");
+    }
+}
+
+@test:Config {}
+function testConstraintsOnRecordArrayMemberFailure() {
+    User[] users = [
+        {id: 1, name: "John"},
+        {id: 2, name: "a"}
+    ];
+
+    do {
+        users = check validate(users);
+        test:assertFail("Unexpected error found.");
+    } on fail error err {
+        test:assertEquals(err.message(), "Validation failed for '$[1].name:minLength' constraint(s).");
+    }
+
+    Users|error validation1 = validate(users);
+    if validation1 is error {
+        test:assertEquals(validation1.message(), "Validation failed for '$[1].name:minLength' constraint(s).");
+    } else {
+        test:assertFail("Unexpected error found.");
+    }
+
+    Users|error validation2 = validate([...users, {id: 3, name: "Joyce"}]);
+    if validation2 is error {
+        test:assertEquals(validation2.message(), "Validation failed for '$:maxLength','$[1].name:minLength' constraint(s).");
+    } else {
+        test:assertFail("Unexpected error found.");
+    }
+}

--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 
 - [Ensure value type after constraint validation](https://github.com/ballerina-platform/ballerina-standard-library/issues/3976)
+- [Fix constraint validation on array members](https://github.com/ballerina-platform/ballerina-standard-library/issues/3974)
 
 ## [1.0.2] - 2023-01-30
 

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -3,7 +3,7 @@
 _Owners_: @TharmiganK @shafreenAnfar @chamil321  
 _Reviewers_: @shafreenAnfar @chamil321  
 _Created_: 2022/08/09  
-_Updated_: 2022/08/09   
+_Updated_: 2023/01/31   
 _Edition_: Swan Lake
 
 ## Introduction

--- a/native/src/main/java/io/ballerina/stdlib/constraint/Constraints.java
+++ b/native/src/main/java/io/ballerina/stdlib/constraint/Constraints.java
@@ -19,10 +19,12 @@
 package io.ballerina.stdlib.constraint;
 
 import io.ballerina.runtime.api.types.AnnotatableType;
+import io.ballerina.runtime.api.types.ArrayType;
 import io.ballerina.runtime.api.types.RecordType;
 import io.ballerina.runtime.api.types.Type;
 import io.ballerina.runtime.api.types.UnionType;
 import io.ballerina.runtime.api.utils.TypeUtils;
+import io.ballerina.runtime.api.values.BArray;
 import io.ballerina.runtime.api.values.BError;
 import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BTypedesc;
@@ -35,7 +37,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import static io.ballerina.stdlib.constraint.Constants.SYMBOL_CLOSE_SQUARE_BRACKET;
 import static io.ballerina.stdlib.constraint.Constants.SYMBOL_DOLLAR_SIGN;
+import static io.ballerina.stdlib.constraint.Constants.SYMBOL_OPEN_SQUARE_BRACKET;
 
 /**
  * Extern functions for validating constraints.
@@ -49,7 +53,7 @@ public class Constraints {
             if (value instanceof BError) {
                 return ErrorUtils.buildTypeConversionError((BError) value);
             }
-            List<String> failedConstraints = validateAfterTypeConversion(value, type);
+            List<String> failedConstraints = validateAfterTypeConversion(value, type, SYMBOL_DOLLAR_SIGN);
             if (!failedConstraints.isEmpty()) {
                 return ErrorUtils.buildValidationError(failedConstraints);
             }
@@ -61,15 +65,29 @@ public class Constraints {
         }
     }
 
-    private static List<String> validateAfterTypeConversion(Object value, Type type) {
+    private static List<String> validateArrayMembers(Object value, ArrayType type, String path) {
+        Type memberType = type.getElementType();
+        BArray members = ((BArray) value);
+        List<String> failedConstraints = new ArrayList<>();
+        for (int i = 0; i < members.getLength(); i++) {
+            failedConstraints.addAll(validateAfterTypeConversion(members.get(i), memberType, path +
+                                        SYMBOL_OPEN_SQUARE_BRACKET + i + SYMBOL_CLOSE_SQUARE_BRACKET));
+        }
+        return failedConstraints;
+    }
+
+    private static List<String> validateAfterTypeConversion(Object value, Type type, String path) {
+        if (type instanceof ArrayType) {
+            return validateArrayMembers(value, (ArrayType) type, path);
+        }
         List<String> failedConstraints = new ArrayList<>();
         if (type instanceof AnnotatableType) {
             AbstractAnnotations annotations = getAnnotationImpl(type, failedConstraints);
-            annotations.validate(value, (AnnotatableType) type, SYMBOL_DOLLAR_SIGN);
+            annotations.validate(value, (AnnotatableType) type, path);
         } else if (type instanceof UnionType) {
             Optional<Type> matchingType = getMatchingType(value, type);
             if (matchingType.isPresent()) {
-                return validateAfterTypeConversion(value, matchingType.get());
+                return validateAfterTypeConversion(value, matchingType.get(), path);
             }
         }
         return failedConstraints;


### PR DESCRIPTION
## Purpose

> $Subject

Fixes : https://github.com/ballerina-platform/ballerina-standard-library/issues/3974

## Examples

```bal
import ballerina/constraint;

type User record {|
    int id;
    @constraint:String {
        minLength: 2
    }
    string name;
|};

public function main() returns error? {
    User[] users = [
        {id: 1, name: "John"},
        {id: 2, name: "Joe"},
        {id: 3, name: "A"}
    ];
    users = check constraint:validate(users);
    // error: Validation failed for '$[2].name:minLength' constraint(s).
}
```

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [ ] <s>Updated the spec</s>
- [ ] <s>Checked native-image compatibility</s>
