### PR TITLE
Allow constraint annotations on subtypes

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "constraint"
-version = "1.1.0"
+version = "1.1.1"
 authors = ["Ballerina"]
 keywords = ["constraint", "validation"]
 repository = "https://github.com/ballerina-platform/module-ballerina-constraint"
@@ -12,5 +12,5 @@ distribution = "2201.4.0"
 [[platform.java11.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "constraint-native"
-version = "1.1.0"
-path = "../native/build/libs/constraint-native-1.1.0.jar"
+version = "1.1.1"
+path = "../native/build/libs/constraint-native-1.1.1-SNAPSHOT.jar"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,4 +3,4 @@ id = "constraint-compiler-plugin"
 class = "io.ballerina.stdlib.constraint.compiler.ConstraintCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/constraint-compiler-plugin-1.1.0.jar"
+path = "../compiler-plugin/build/libs/constraint-compiler-plugin-1.1.1-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -9,7 +9,7 @@ dependencies-toml-version = "2"
 [[package]]
 org = "ballerina"
 name = "constraint"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "test"}

--- a/ballerina/tests/advanced_constraint_test.bal
+++ b/ballerina/tests/advanced_constraint_test.bal
@@ -590,7 +590,6 @@ function testInvalidLengthConstraintOnArrayRecordField() {
     }
 }
 
-
 // Testing annotation validations with union type desc
 
 type Union1 record {|
@@ -714,6 +713,116 @@ function testCustomAnnotationFailure() {
     OrderNew|error validation = validate(rec);
     if validation is error {
         test:assertEquals(validation.message(), "Validation failed for '$.userId:length' constraint(s).");
+    } else {
+        test:assertFail("Expected error not found.");
+    }
+}
+
+// Constraint on subtypes
+
+@String {
+    minLength: 2
+}
+type Name string;
+
+@String {
+    maxLength: 10
+}
+type NickName Name;
+
+@Int {
+    maxValue: 1000
+}
+type Id int:Signed32;
+
+@test:Config {}
+function testConstraintAnnotationOnSubtypeSuccess1() {
+    NickName|error validation = validate("J");
+    if validation is error {
+        test:assertFail("Unexpected error found.");
+    }
+}
+
+@test:Config {}
+function testConstraintAnnotationOnSubtypeSuccess2() {
+    Id|error validation = validate(100);
+    if validation is error {
+        test:assertFail("Unexpected error found.");
+    }
+}
+
+@test:Config {}
+function testConstraintAnnotationOnSubtypeFailure1() {
+    NickName|error validation = validate("James Maccurdy");
+    if validation is error {
+        test:assertEquals(validation.message(), "Validation failed for '$:maxLength' constraint(s).");
+    } else {
+        test:assertFail("Expected error not found.");
+    }
+}
+
+@test:Config {}
+function testConstraintAnnotationOnSubtypeFailure2() {
+    Id|error validation = validate(1001);
+    if validation is error {
+        test:assertEquals(validation.message(), "Validation failed for '$:maxValue' constraint(s).");
+    } else {
+        test:assertFail("Expected error not found.");
+    }
+}
+
+type FullName record {|
+    @String {
+        maxLength: 20
+    }
+    Name firstName;
+    Name lastName;
+|};
+
+type UserNew record {
+    @Int {
+        minValue: 1
+    }
+    int:Signed32 id;
+    FullName name;
+    @String {
+        minLength: 2
+    }
+    Name nickName?; 
+    int age;
+};
+
+@test:Config {}
+function testConstraintAnnotationOnSubtypeAsRecordFieldSuccess() {
+    UserNew user = {
+        id: 1,
+        name: {
+            firstName: "John",
+            lastName: "Doe"
+        },
+        nickName: "JD",
+        age: 20
+    };
+    UserNew|error validation = validate(user);
+    if validation is error {
+        test:assertFail("Unexpected error found.");
+    }
+}
+
+@test:Config {}
+function testConstraintAnnotationOnSubtypeAsRecordFieldFailure() {
+    UserNew user = {
+        id: 1,
+        name: {
+            firstName: "John",
+            lastName: "Doe"
+        },
+        nickName: "J",
+        age: 20
+    };
+    UserNew|error validation = validate(user);
+    if validation is error {
+        test:assertEquals(validation.message(), "Validation failed for '$.nickName:minLength','$.nickName:minLength' constraint(s).");
     } else {
         test:assertFail("Expected error not found.");
     }

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,12 @@ This file contains all the notable changes done to the Ballerina Constraint pack
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- [Allow constraints on subtypes](https://github.com/ballerina-platform/ballerina-standard-library/issues/4349)
+
 ## [1.1.0] - 2023-02-20
 
 ### Fixed

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/constraint/compiler/CompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/constraint/compiler/CompilerPluginTest.java
@@ -130,7 +130,7 @@ public class CompilerPluginTest {
         Package currentPackage = CompilerPluginTestUtils.loadPackage("sample_package_7");
         PackageCompilation compilation = currentPackage.getCompilation();
         DiagnosticResult diagnosticResult = compilation.diagnosticResult();
-        Assert.assertEquals(diagnosticResult.errorCount(), 22);
+        Assert.assertEquals(diagnosticResult.errorCount(), 23);
         CompilerPluginTestUtils.assertError101(diagnosticResult, 0, ANNOTATION_TAG_INT, "int?");
         CompilerPluginTestUtils.assertError101(diagnosticResult, 1, ANNOTATION_TAG_INT, "int|float");
         CompilerPluginTestUtils.assertError101(diagnosticResult, 2, ANNOTATION_TAG_FLOAT, "float?");
@@ -153,6 +153,7 @@ public class CompilerPluginTest {
         CompilerPluginTestUtils.assertError101(diagnosticResult, 19, ANNOTATION_TAG_STRING, "string|int");
         CompilerPluginTestUtils.assertError101(diagnosticResult, 20, ANNOTATION_TAG_ARRAY, "anydata[]?");
         CompilerPluginTestUtils.assertError101(diagnosticResult, 21, ANNOTATION_TAG_ARRAY, "int[]|float[]?");
+        CompilerPluginTestUtils.assertError101(diagnosticResult, 22, ANNOTATION_TAG_STRING, "int:Signed32");
     }
 
     @Test

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_1/sample.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_1/sample.bal
@@ -90,3 +90,39 @@ type StringA string;
     minValue: getA()
 }
 type IntA int;
+
+@constraint:String {
+    minLength: 2
+}
+type Name string;
+
+@constraint:String {
+    maxLength: 10
+}
+type NickName Name;
+
+@constraint:Int {
+    maxValue: 1000
+}
+type Id int:Signed32;
+
+type FullName record {|
+    @constraint:String {
+        maxLength: 20
+    }
+    Name firstName;
+    Name lastName;
+|};
+
+type UserNew record {
+    @constraint:Int {
+        minValue: 1
+    }
+    int:Signed32 id;
+    FullName name;
+    @constraint:String {
+        minLength: 2
+    }
+    Name nickName?; 
+    int age;
+};

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_7/sample.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_7/sample.bal
@@ -156,3 +156,8 @@ type UnionArrayType2 int[]|float[];
     maxLength: 10
 }
 type UnionArrayType3 int[]|float[]?;
+
+@constraint:String {
+    minLength: 1000
+}
+type Id int:Signed32;

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/constraint/compiler/ConstraintCompatibilityMatrix.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/constraint/compiler/ConstraintCompatibilityMatrix.java
@@ -18,6 +18,8 @@
 
 package io.ballerina.stdlib.constraint.compiler;
 
+import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
 import io.ballerina.stdlib.constraint.compiler.annotation.tag.AnnotationTag;
 import io.ballerina.stdlib.constraint.compiler.annotation.tag.AnnotationTagArray;
 import io.ballerina.stdlib.constraint.compiler.annotation.tag.AnnotationTagFloat;
@@ -50,8 +52,9 @@ public class ConstraintCompatibilityMatrix {
         matrix.put(ANNOTATION_TAG_ARRAY, new AnnotationTagArray());
     }
 
-    boolean isAnnotationTagCompatible(String annotationTag, String fieldType) {
-        return matrix.get(annotationTag).isCompatibleFieldType(fieldType);
+    boolean isAnnotationTagCompatibleWithTypeSymbol(SyntaxNodeAnalysisContext ctx, String annotationTag,
+                                                    TypeSymbol fielsTypeSymbol) {
+        return matrix.get(annotationTag).isCompatibleFieldType(ctx, fielsTypeSymbol);
     }
 
     boolean isAnnotationConstraintsCompatible(String annotationTag, ArrayList<String> constraints) {

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/constraint/compiler/ConstraintCompilerPluginUtils.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/constraint/compiler/ConstraintCompilerPluginUtils.java
@@ -18,6 +18,7 @@
 
 package io.ballerina.stdlib.constraint.compiler;
 
+import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.syntax.tree.AnnotationNode;
 import io.ballerina.compiler.syntax.tree.BasicLiteralNode;
 import io.ballerina.compiler.syntax.tree.ExpressionNode;
@@ -28,7 +29,6 @@ import io.ballerina.compiler.syntax.tree.NodeLocation;
 import io.ballerina.compiler.syntax.tree.SeparatedNodeList;
 import io.ballerina.compiler.syntax.tree.SpecificFieldNode;
 import io.ballerina.compiler.syntax.tree.UnaryExpressionNode;
-import io.ballerina.compiler.syntax.tree.UnionTypeDescriptorNode;
 import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
 import io.ballerina.tools.diagnostics.DiagnosticFactory;
 import io.ballerina.tools.diagnostics.DiagnosticInfo;
@@ -52,22 +52,13 @@ public class ConstraintCompilerPluginUtils {
 
     private static final ConstraintCompatibilityMatrix matrix = new ConstraintCompatibilityMatrix();
 
-    static void populateFieldTypeList(UnionTypeDescriptorNode node, ArrayList<String> fieldTypeList) {
-        fieldTypeList.add(node.rightTypeDesc().toString().trim());
-        if (node.leftTypeDesc() instanceof UnionTypeDescriptorNode) {
-            populateFieldTypeList((UnionTypeDescriptorNode) node.leftTypeDesc(), fieldTypeList);
-        } else {
-            fieldTypeList.add(node.leftTypeDesc().toString().trim());
-        }
-    }
-
     static void validateConstraints(SyntaxNodeAnalysisContext ctx, NodeList<AnnotationNode> annotationNodes,
-                                    String fieldType, ArrayList<String> fieldTypeList) {
+                                    String fieldType, TypeSymbol fieldTypeSymbol) {
         for (AnnotationNode annotationNode : annotationNodes) {
             String[] annotationParts = annotationNode.annotReference().toString().trim().split(SYMBOL_COLON);
             if (annotationParts[0].equals(MODULE_NAME)) {
                 String annotationTag = annotationParts[1];
-                checkAnnotationTagCompatibility(ctx, annotationNode, annotationTag, fieldType, fieldTypeList);
+                checkAnnotationTagCompatibility(ctx, annotationNode, annotationTag, fieldType, fieldTypeSymbol);
                 checkAnnotationConstraintsAvailability(ctx, annotationNode, annotationTag, fieldType);
                 checkAnnotationConstraintsCompatibility(ctx, annotationNode, annotationTag, fieldType);
                 checkAnnotationConstraintsValidity(ctx, annotationNode, annotationTag, fieldType);
@@ -77,12 +68,9 @@ public class ConstraintCompilerPluginUtils {
 
     private static void checkAnnotationTagCompatibility(SyntaxNodeAnalysisContext ctx, AnnotationNode annotationNode,
                                                         String annotationTag, String fieldType,
-                                                        ArrayList<String> fieldTypeList) {
-        for (String type : fieldTypeList) {
-            if (!matrix.isAnnotationTagCompatible(annotationTag, type)) {
-                reportAnnotationTagIncompatibility(ctx, annotationTag, fieldType, annotationNode.location());
-                break;
-            }
+                                                        TypeSymbol fieldTypeSymbol) {
+        if (!matrix.isAnnotationTagCompatibleWithTypeSymbol(ctx, annotationTag, fieldTypeSymbol)) {
+            reportAnnotationTagIncompatibility(ctx, annotationTag, fieldType, annotationNode.location());
         }
     }
 

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/constraint/compiler/RecordFieldConstraintValidator.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/constraint/compiler/RecordFieldConstraintValidator.java
@@ -18,21 +18,21 @@
 
 package io.ballerina.stdlib.constraint.compiler;
 
+import io.ballerina.compiler.api.symbols.RecordFieldSymbol;
+import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.syntax.tree.AnnotationNode;
 import io.ballerina.compiler.syntax.tree.MetadataNode;
 import io.ballerina.compiler.syntax.tree.NodeList;
 import io.ballerina.compiler.syntax.tree.RecordFieldNode;
-import io.ballerina.compiler.syntax.tree.UnionTypeDescriptorNode;
 import io.ballerina.projects.plugins.AnalysisTask;
 import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
 import io.ballerina.tools.diagnostics.Diagnostic;
 import io.ballerina.tools.diagnostics.DiagnosticSeverity;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import static io.ballerina.stdlib.constraint.compiler.ConstraintCompilerPluginUtils.populateFieldTypeList;
 import static io.ballerina.stdlib.constraint.compiler.ConstraintCompilerPluginUtils.validateConstraints;
 
 /**
@@ -58,13 +58,13 @@ public class RecordFieldConstraintValidator implements AnalysisTask<SyntaxNodeAn
             return;
         }
         NodeList<AnnotationNode> annotationNodes = optionalMetadataNode.get().annotations();
-        String fieldType = recordFieldNode.typeName().toString().trim();
-        ArrayList<String> fieldTypeList = new ArrayList<>();
-        if (recordFieldNode.typeName() instanceof UnionTypeDescriptorNode) {
-            populateFieldTypeList((UnionTypeDescriptorNode) recordFieldNode.typeName(), fieldTypeList);
-        } else {
-            fieldTypeList.add(fieldType);
+        Optional<Symbol> optionalTypeSymbol = ctx.semanticModel().symbol(recordFieldNode);
+        if (optionalTypeSymbol.isEmpty() || !(optionalTypeSymbol.get() instanceof RecordFieldSymbol)) {
+            return;
         }
-        validateConstraints(ctx, annotationNodes, fieldType, fieldTypeList);
+        RecordFieldSymbol recordFieldSymbol = (RecordFieldSymbol) optionalTypeSymbol.get();
+        TypeSymbol fieldTypeSymbol = recordFieldSymbol.typeDescriptor();
+        String fieldType = recordFieldNode.typeName().toString().trim();
+        validateConstraints(ctx, annotationNodes, fieldType, fieldTypeSymbol);
     }
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/constraint/compiler/TypeConstraintValidator.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/constraint/compiler/TypeConstraintValidator.java
@@ -18,21 +18,21 @@
 
 package io.ballerina.stdlib.constraint.compiler;
 
+import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.api.symbols.TypeDefinitionSymbol;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.syntax.tree.AnnotationNode;
 import io.ballerina.compiler.syntax.tree.MetadataNode;
 import io.ballerina.compiler.syntax.tree.NodeList;
 import io.ballerina.compiler.syntax.tree.TypeDefinitionNode;
-import io.ballerina.compiler.syntax.tree.UnionTypeDescriptorNode;
 import io.ballerina.projects.plugins.AnalysisTask;
 import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
 import io.ballerina.tools.diagnostics.Diagnostic;
 import io.ballerina.tools.diagnostics.DiagnosticSeverity;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import static io.ballerina.stdlib.constraint.compiler.ConstraintCompilerPluginUtils.populateFieldTypeList;
 import static io.ballerina.stdlib.constraint.compiler.ConstraintCompilerPluginUtils.validateConstraints;
 
 /**
@@ -58,13 +58,13 @@ public class TypeConstraintValidator implements AnalysisTask<SyntaxNodeAnalysisC
             return;
         }
         NodeList<AnnotationNode> annotationNodes = optionalMetadataNode.get().annotations();
-        String fieldType = typeDefinitionNode.typeDescriptor().toString().trim();
-        ArrayList<String> fieldTypeList = new ArrayList<>();
-        if (typeDefinitionNode.typeDescriptor() instanceof UnionTypeDescriptorNode) {
-            populateFieldTypeList((UnionTypeDescriptorNode) typeDefinitionNode.typeDescriptor(), fieldTypeList);
-        } else {
-            fieldTypeList.add(fieldType);
+        Optional<Symbol> optionalTypeSymbol = ctx.semanticModel().symbol(typeDefinitionNode);
+        if (optionalTypeSymbol.isEmpty() || !(optionalTypeSymbol.get() instanceof TypeDefinitionSymbol)) {
+            return;
         }
-        validateConstraints(ctx, annotationNodes, fieldType, fieldTypeList);
+        TypeDefinitionSymbol typeDefinitionSymbol = (TypeDefinitionSymbol) optionalTypeSymbol.get();
+        TypeSymbol fieldTypeSymbol = typeDefinitionSymbol.typeDescriptor();
+        String fieldType = typeDefinitionNode.typeDescriptor().toString().trim();
+        validateConstraints(ctx, annotationNodes, fieldType, fieldTypeSymbol);
     }
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/constraint/compiler/annotation/tag/AnnotationTag.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/constraint/compiler/annotation/tag/AnnotationTag.java
@@ -18,6 +18,9 @@
 
 package io.ballerina.stdlib.constraint.compiler.annotation.tag;
 
+import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
+
 import java.util.ArrayList;
 
 /**
@@ -25,7 +28,7 @@ import java.util.ArrayList;
  */
 public interface AnnotationTag {
 
-    boolean isCompatibleFieldType(String fieldType);
+    boolean isCompatibleFieldType(SyntaxNodeAnalysisContext ctx, TypeSymbol fieldTypeSymbol);
 
     boolean haveCompatibleConstraints(ArrayList<String> constraints);
 

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/constraint/compiler/annotation/tag/AnnotationTagArray.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/constraint/compiler/annotation/tag/AnnotationTagArray.java
@@ -18,7 +18,8 @@
 
 package io.ballerina.stdlib.constraint.compiler.annotation.tag;
 
-import static io.ballerina.stdlib.constraint.compiler.Constants.SYMBOL_ARRAY;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
 
 /**
  * The class to represent the `@constraint:Array` annotation tag.
@@ -26,7 +27,8 @@ import static io.ballerina.stdlib.constraint.compiler.Constants.SYMBOL_ARRAY;
 public class AnnotationTagArray implements LengthConstrainedAnnotationTag {
 
     @Override
-    public boolean isCompatibleFieldType(String fieldType) {
-        return fieldType.endsWith(SYMBOL_ARRAY);
+    public boolean isCompatibleFieldType(SyntaxNodeAnalysisContext ctx, TypeSymbol fieldTypeSymbol) {
+        return fieldTypeSymbol.subtypeOf(ctx.semanticModel().types().builder().ARRAY_TYPE.
+                withType(ctx.semanticModel().types().ANYDATA).build());
     }
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/constraint/compiler/annotation/tag/AnnotationTagFloat.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/constraint/compiler/annotation/tag/AnnotationTagFloat.java
@@ -18,7 +18,8 @@
 
 package io.ballerina.stdlib.constraint.compiler.annotation.tag;
 
-import static io.ballerina.stdlib.constraint.compiler.Constants.TYPE_FLOAT;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
 
 /**
  * The class to represent the `@constraint:Float` annotation tag.
@@ -26,7 +27,7 @@ import static io.ballerina.stdlib.constraint.compiler.Constants.TYPE_FLOAT;
 public class AnnotationTagFloat implements ValueConstrainedAnnotationTag {
 
     @Override
-    public boolean isCompatibleFieldType(String fieldType) {
-        return fieldType.equals(TYPE_FLOAT);
+    public boolean isCompatibleFieldType(SyntaxNodeAnalysisContext ctx, TypeSymbol fieldTypeSymbol) {
+        return fieldTypeSymbol.subtypeOf(ctx.semanticModel().types().FLOAT);
     }
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/constraint/compiler/annotation/tag/AnnotationTagInt.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/constraint/compiler/annotation/tag/AnnotationTagInt.java
@@ -18,7 +18,8 @@
 
 package io.ballerina.stdlib.constraint.compiler.annotation.tag;
 
-import static io.ballerina.stdlib.constraint.compiler.Constants.TYPE_INT;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
 
 /**
  * The class to represent the `@constraint:Int` annotation tag.
@@ -26,7 +27,7 @@ import static io.ballerina.stdlib.constraint.compiler.Constants.TYPE_INT;
 public class AnnotationTagInt implements ValueConstrainedAnnotationTag {
 
     @Override
-    public boolean isCompatibleFieldType(String fieldType) {
-        return fieldType.equals(TYPE_INT);
+    public boolean isCompatibleFieldType(SyntaxNodeAnalysisContext ctx, TypeSymbol fieldTypeSymbol) {
+        return fieldTypeSymbol.subtypeOf(ctx.semanticModel().types().INT);
     }
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/constraint/compiler/annotation/tag/AnnotationTagNumber.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/constraint/compiler/annotation/tag/AnnotationTagNumber.java
@@ -18,9 +18,8 @@
 
 package io.ballerina.stdlib.constraint.compiler.annotation.tag;
 
-import static io.ballerina.stdlib.constraint.compiler.Constants.TYPE_DECIMAL;
-import static io.ballerina.stdlib.constraint.compiler.Constants.TYPE_FLOAT;
-import static io.ballerina.stdlib.constraint.compiler.Constants.TYPE_INT;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
 
 /**
  * The class to represent the `@constraint:Number` annotation tag.
@@ -28,7 +27,10 @@ import static io.ballerina.stdlib.constraint.compiler.Constants.TYPE_INT;
 public class AnnotationTagNumber implements ValueConstrainedAnnotationTag {
 
     @Override
-    public boolean isCompatibleFieldType(String fieldType) {
-        return fieldType.equals(TYPE_INT) || fieldType.equals(TYPE_FLOAT) || fieldType.equals(TYPE_DECIMAL);
+    public boolean isCompatibleFieldType(SyntaxNodeAnalysisContext ctx, TypeSymbol fieldTypeSymbol) {
+        return fieldTypeSymbol.subtypeOf(ctx.semanticModel().types().builder().UNION_TYPE.withMemberTypes(
+                ctx.semanticModel().types().INT,
+                ctx.semanticModel().types().FLOAT,
+                ctx.semanticModel().types().DECIMAL).build());
     }
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/constraint/compiler/annotation/tag/AnnotationTagString.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/constraint/compiler/annotation/tag/AnnotationTagString.java
@@ -18,7 +18,8 @@
 
 package io.ballerina.stdlib.constraint.compiler.annotation.tag;
 
-import static io.ballerina.stdlib.constraint.compiler.Constants.TYPE_STRING;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
 
 /**
  * The class to represent the `@constraint:String` annotation tag.
@@ -26,7 +27,7 @@ import static io.ballerina.stdlib.constraint.compiler.Constants.TYPE_STRING;
 public class AnnotationTagString implements LengthConstrainedAnnotationTag {
 
     @Override
-    public boolean isCompatibleFieldType(String fieldType) {
-        return fieldType.equals(TYPE_STRING);
+    public boolean isCompatibleFieldType(SyntaxNodeAnalysisContext ctx, TypeSymbol fieldTypeSymbol) {
+        return fieldTypeSymbol.subtypeOf(ctx.semanticModel().types().STRING);
     }
 }


### PR DESCRIPTION
## Purpose
> $Subject

Fixes: https://github.com/ballerina-platform/ballerina-standard-library/issues/4349

## Examples

```bal
import ballerina/constraint;

@constraint:String {
    minLength: 2
}
type Name string;

@constraint:String {
    pattern: re `^[a-zA-Z0-9_]*$`
}
type FullName Name;
```

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [ ] ~Updated the spec~
- [ ] ~Checked native-image compatibility~
