### PR TITLE
Fix issues with Dead Code Elimination feature

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,13 +1,13 @@
 [package]
 org = "ballerina"
 name = "constraint"
-version = "1.5.1"
+version = "1.6.0"
 authors = ["Ballerina"]
 keywords = ["constraint", "validation"]
 repository = "https://github.com/ballerina-platform/module-ballerina-constraint"
 icon = "icon.png"
 license = ["Apache-2.0"]
-distribution = "2201.8.0"
+distribution = "2201.11.0"
 
 [platform.java17]
 graalvmCompatible = true
@@ -15,5 +15,5 @@ graalvmCompatible = true
 [[platform.java17.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "constraint-native"
-version = "1.5.1"
-path = "../native/build/libs/constraint-native-1.5.1-SNAPSHOT.jar"
+version = "1.6.0"
+path = "../native/build/libs/constraint-native-1.6.0-SNAPSHOT.jar"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,4 +3,4 @@ id = "constraint-compiler-plugin"
 class = "io.ballerina.stdlib.constraint.compiler.ConstraintCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/constraint-compiler-plugin-1.5.1-SNAPSHOT.jar"
+path = "../compiler-plugin/build/libs/constraint-compiler-plugin-1.6.0-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -5,12 +5,12 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.8.0"
+distribution-version = "2201.11.0-20241101-105200-f94714be"
 
 [[package]]
 org = "ballerina"
 name = "constraint"
-version = "1.5.1"
+version = "1.6.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "test"},
@@ -30,6 +30,26 @@ modules = [
 
 [[package]]
 org = "ballerina"
+name = "lang.__internal"
+version = "0.0.0"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "lang.object"}
+]
+
+[[package]]
+org = "ballerina"
+name = "lang.array"
+version = "0.0.0"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "lang.__internal"}
+]
+
+[[package]]
+org = "ballerina"
 name = "lang.error"
 version = "0.0.0"
 scope = "testOnly"
@@ -39,11 +59,18 @@ dependencies = [
 
 [[package]]
 org = "ballerina"
+name = "lang.object"
+version = "0.0.0"
+scope = "testOnly"
+
+[[package]]
+org = "ballerina"
 name = "test"
 version = "0.0.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "lang.array"},
 	{org = "ballerina", name = "lang.error"}
 ]
 modules = [
@@ -53,7 +80,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "time"
-version = "2.4.0"
+version = "2.6.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}

--- a/ballerina/constraint_errors.bal
+++ b/ballerina/constraint_errors.bal
@@ -14,11 +14,15 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import ballerina/jballerina.java;
+
 # Represents the generic error type of the module.
 public type Error distinct error;
 
 # Represents the errors occurs during constraint validations.
+@java:ExternalDependency
 public type ValidationError distinct Error;
 
 # Represents the errors occurs during the type conversion.
+@java:ExternalDependency
 public type TypeConversionError distinct Error;

--- a/build-config/resources/Ballerina.toml
+++ b/build-config/resources/Ballerina.toml
@@ -7,7 +7,7 @@ keywords = ["constraint", "validation"]
 repository = "https://github.com/ballerina-platform/module-ballerina-constraint"
 icon = "icon.png"
 license = ["Apache-2.0"]
-distribution = "2201.8.0"
+distribution = "2201.11.0"
 
 [platform.java17]
 graalvmCompatible = true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,13 +1,13 @@
 org.gradle.caching=true
 group=io.ballerina.stdlib
-version=1.5.1-SNAPSHOT
+version=1.6.0-SNAPSHOT
 puppycrawlCheckstyleVersion=10.12.0
 slf4jVersion=1.7.30
 testngVersion=7.6.1
 ballerinaGradlePluginVersion=2.2.3
 jacocoVersion=0.8.10
 
-ballerinaLangVersion=2201.8.0
+ballerinaLangVersion=2201.11.0-20241101-105200-f94714be
 
 # Test dependency
-stdlibTimeVersion=2.4.0
+stdlibTimeVersion=2.6.0-20241106-140700-1bb5302


### PR DESCRIPTION
## Purpose

> $Subject

Part of: https://github.com/ballerina-platform/ballerina-library/issues/7339

There are no usages of `ValueCreator` or `TypeCreator` APIs. But there are usages of [`ErrorCreator` APIs](https://github.com/search?q=repo%3Aballerina-platform%2Fmodule-ballerina-constraint%20%22ErrorCreator.%22&type=code). Since the following sub types of `constraint:Error` are created from the native code and not referred in any of the external function return types, we need to mark them as `ExternalDependency`.
1. `constraint:ValidationError`
2. `constraint:TypeConversionError`

## Examples

N/A

## Checklist
- [x] Linked to an issue
- [ ] ~Updated the changelog~
- [ ] ~Added tests~
- [ ] ~Updated the spec~
- [x] Checked native-image compatibility
