### PR TITLE
Upgrade Gradle to 9.5.1 and Ballerina Gradle plugin to 4.0.0

### DIFF
--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -16,6 +16,13 @@
  */
 
 import org.apache.tools.ant.taskdefs.condition.Os
+import org.gradle.process.ExecOperations
+
+import javax.inject.Inject
+
+abstract class BallerinaExecHelper {
+    @Inject abstract ExecOperations getExecOperations()
+}
 
 buildscript {
     repositories {
@@ -76,8 +83,9 @@ task updateTomlFiles {
 }
 
 task commitTomlFiles {
+    def execHelper = project.objects.newInstance(BallerinaExecHelper)
     doLast {
-        project.exec {
+        execHelper.execOperations.exec {
             ignoreExitValue true
             if (Os.isFamily(Os.FAMILY_WINDOWS)) {
                 commandLine 'cmd', '/c', "git commit Ballerina.toml Dependencies.toml CompilerPlugin.toml -m '[Automated] Update the native jar versions'"

--- a/build-config/checkstyle/build.gradle
+++ b/build-config/checkstyle/build.gradle
@@ -28,7 +28,7 @@ task downloadCheckstyleRuleFiles(type: Download) {
     ])
     overwrite false
     onlyIfNewer true
-    dest buildDir
+    dest layout.buildDirectory.get().asFile
 }
 
 jar {
@@ -39,10 +39,10 @@ clean {
     enabled = false
 }
 
-artifacts.add('default', file("$project.buildDir/checkstyle.xml")) {
+artifacts.add('default', layout.buildDirectory.file("checkstyle.xml")) {
     builtBy('downloadCheckstyleRuleFiles')
 }
 
-artifacts.add('default', file("$project.buildDir/suppressions.xml")) {
+artifacts.add('default', layout.buildDirectory.file("suppressions.xml")) {
     builtBy('downloadCheckstyleRuleFiles')
 }

--- a/build-config/checkstyle/build.gradle
+++ b/build-config/checkstyle/build.gradle
@@ -46,3 +46,5 @@ artifacts.add('default', layout.buildDirectory.file("checkstyle.xml")) {
 artifacts.add('default', layout.buildDirectory.file("suppressions.xml")) {
     builtBy('downloadCheckstyleRuleFiles')
 }
+
+test.mustRunAfter(downloadCheckstyleRuleFiles)

--- a/build.gradle
+++ b/build.gradle
@@ -16,10 +16,10 @@
  */
 
 plugins {
-    id "com.github.spotbugs" version "6.0.18"
+    id "com.github.spotbugs" version "6.5.1"
     id "com.github.johnrengelman.shadow" version "7.1.2"
     id "de.undercouch.download" version "5.4.0"
-    id "net.researchgate.release" version "2.8.0"
+    id "net.researchgate.release" version "3.1.0"
 }
 
 ext.puppycrawlCheckstyleVersion = project.puppycrawlCheckstyleVersion
@@ -90,6 +90,6 @@ release {
     }
 }
 
-task build {
+tasks.named('build') {
     dependsOn('constraint-ballerina:build')
 }

--- a/build.gradle
+++ b/build.gradle
@@ -90,6 +90,14 @@ release {
     }
 }
 
-tasks.named('build') {
-    dependsOn('constraint-ballerina:build')
+if (tasks.names.contains('build')) {
+    tasks.named('build') {
+        dependsOn('constraint-ballerina:build')
+
+    }
+} else {
+    tasks.register('build') {
+        dependsOn('constraint-ballerina:build')
+
+    }
 }

--- a/compiler-plugin-tests/build.gradle
+++ b/compiler-plugin-tests/build.gradle
@@ -25,7 +25,7 @@ plugins {
 
 jacoco {
     toolVersion = "${jacocoVersion}"
-    reportsDirectory = file("$project.buildDir/reports/jacoco")
+    reportsDirectory = layout.buildDirectory.dir("reports/jacoco")
 }
 
 description = 'Ballerina - Constraint Compiler Plugin Tests'
@@ -60,7 +60,7 @@ spotbugsTest {
     def SpotBugsEffort = classLoader.findLoadedClass("com.github.spotbugs.snom.Effort")
     effort = SpotBugsEffort.MAX
     reportLevel = SpotBugsConfidence.LOW
-    reportsDir = file("$project.buildDir/reports/spotbugs")
+    reportsDir = layout.buildDirectory.dir("reports/spotbugs")
     reports {
         html.enabled true
         text.enabled = true

--- a/compiler-plugin/build.gradle
+++ b/compiler-plugin/build.gradle
@@ -52,7 +52,7 @@ spotbugsMain {
     def SpotBugsEffort = classLoader.findLoadedClass("com.github.spotbugs.snom.Effort")
     effort = SpotBugsEffort.MAX
     reportLevel = SpotBugsConfidence.LOW
-    reportsDir = file("$project.buildDir/reports/spotbugs")
+    reportsDir = layout.buildDirectory.dir("reports/spotbugs")
     reports {
         html.enabled true
         text.enabled = true

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,8 +4,8 @@ version=1.7.1-SNAPSHOT
 puppycrawlCheckstyleVersion=10.12.0
 slf4jVersion=1.7.30
 testngVersion=7.6.1
-ballerinaGradlePluginVersion=2.3.0
-jacocoVersion=0.8.10
+ballerinaGradlePluginVersion=4.0.0
+jacocoVersion=0.8.14
 githubSpotbugsVersion=6.0.18
 
 ballerinaLangVersion=2201.12.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,8 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionSha256Sum=bafc141b619ad6350fd975fc903156dd5c151998cc8b058e8c1044ab5f7b031f

--- a/native/build.gradle
+++ b/native/build.gradle
@@ -47,7 +47,7 @@ spotbugsMain {
     def SpotBugsEffort = classLoader.findLoadedClass("com.github.spotbugs.snom.Effort")
     effort = SpotBugsEffort.MAX
     reportLevel = SpotBugsConfidence.LOW
-    reportsDir = file("$project.buildDir/reports/spotbugs")
+    reportsDir = layout.buildDirectory.dir("reports/spotbugs")
     reports {
         html.enabled true
         text.enabled = true

--- a/settings.gradle
+++ b/settings.gradle
@@ -8,7 +8,7 @@
  */
 
 plugins {
-    id "com.gradle.enterprise" version "3.2"
+    id "com.gradle.develocity" version "3.19.2"
 }
 
 rootProject.name = 'constraint'
@@ -25,9 +25,9 @@ project(':constraint-ballerina').projectDir = file('ballerina')
 project(':constraint-compiler-plugin').projectDir = file('compiler-plugin')
 project(':constraint-compiler-plugin-tests').projectDir = file('compiler-plugin-tests')
 
-gradleEnterprise {
+develocity {
     buildScan {
-        termsOfServiceUrl = 'https://gradle.com/terms-of-service'
-        termsOfServiceAgree = 'yes'
+        termsOfUseUrl = 'https://gradle.com/help/legal-terms-of-use'
+        termsOfUseAgree = 'yes'
     }
 }


### PR DESCRIPTION
## Summary
- Upgrade the Gradle wrapper to 9.5.1 (with distribution checksum) and the Ballerina Gradle plugin to 4.0.0, needed for Java 21/25 compatibility.
- Fix Gradle 9 breakage: `project.exec` calls now use an injected `ExecOperations`, `com.gradle.enterprise` is migrated to `com.gradle.develocity`, any `task build {}` redefinition is replaced with `tasks.named('build')`, and checkstyle's `build.gradle` drops the deprecated `buildDir` property.

## Test plan
- [x] `./gradlew clean build` passes locally on Gradle 9.5.1 with plugin 4.0.0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Upgraded Gradle to 9.5.1 with a distribution checksum.
- Upgraded the Ballerina Gradle plugin to 4.0.0 and JaCoCo to 0.8.14.
- Updated build scripts for Gradle 9 compatibility with `ExecOperations`, `layout.buildDirectory`, named task APIs, and task ordering.
- Replaced Gradle Enterprise with Develocity 3.19.2.
- Updated SpotBugs and release plugin versions.
- Verified the changes with `./gradlew clean build`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->